### PR TITLE
Implement CI/CD release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Download dist artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  tests:
+    name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12"]
-
+    env:
+      PYTHONPATH: src:.
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -35,9 +37,112 @@ jobs:
       - name: Install package and test dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install -e ".[dev,plots,detectors]"
+          python -m pip install -e ".[dev,plots,detectors]"
 
       - name: Run test suite
-        env:
-          PYTHONPATH: src:.
-        run: pytest -q
+        run: python -m pytest -q
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and lint dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -e ".[dev,plots,detectors]"
+
+      - name: Run lint
+        run: python -m ruff check .
+
+  type-check:
+    name: Type Check (Non-Blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and type-check dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -e ".[dev,plots,detectors]"
+
+      - name: Run type check
+        run: python -m mypy --ignore-missing-imports src
+
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build package
+        run: |
+          rm -rf dist build *.egg-info
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check --strict dist/*
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error
+
+  wheel-smoke:
+    name: Wheel Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: build-check
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dist
+          path: dist
+
+      - name: Smoke install wheel
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import tsconformal
+          from tsconformal import SegmentedTransportCalibrator
+
+          print(tsconformal.__version__)
+          print(SegmentedTransportCalibrator)
+          PY

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@3c8d1abf587ffce02620e8b44b3f91275ccbbd7d
         with:
           languages: python
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: pip
@@ -44,4 +44,4 @@ jobs:
           pip install -e ".[dev,plots,detectors]"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@3c8d1abf587ffce02620e8b44b3f91275ccbbd7d

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,257 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Ref to build for dry run"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  version_guard:
+    name: Version Guard
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install release-check dependencies
+        run: |
+          python -m pip install --upgrade pip packaging PyYAML
+
+      - name: Check release version
+        id: version
+        run: |
+          python scripts/check_release_version.py
+
+      - name: Enforce main-only release policy
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          TAG_COMMIT="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          git merge-base --is-ancestor "$TAG_COMMIT" origin/main
+
+  quality:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+    needs: version_guard
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    env:
+      PYTHONPATH: src:.
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package and quality-check dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install -e ".[dev,plots,detectors]"
+
+      - name: Run tests
+        run: python -m pytest -q
+
+      - name: Run lint
+        run: python -m ruff check .
+
+      - name: Run type check (non-blocking)
+        continue-on-error: true
+        run: python -m mypy --ignore-missing-imports src
+
+  build:
+    name: Build Distribution Artifacts
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build package
+        run: |
+          rm -rf dist build *.egg-info
+          python -m pip install --upgrade pip build twine
+          python -m build
+          python -m twine check --strict dist/*
+
+      - name: Smoke install wheel
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          import tsconformal
+          from tsconformal import SegmentedTransportCalibrator
+
+          print(tsconformal.__version__)
+          print(SegmentedTransportCalibrator)
+          PY
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish_testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [version_guard, build]
+    if: >
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.version_guard.outputs.is_prerelease == 'true'
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+
+  publish_pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [version_guard, build]
+    if: >
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.version_guard.outputs.is_prerelease == 'false'
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598
+        with:
+          packages-dir: dist/
+
+  github_prerelease:
+    name: Create GitHub Prerelease
+    runs-on: ubuntu-latest
+    needs: [publish_testpypi]
+    if: >
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dist
+          path: dist
+
+      - name: Create or update GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          REPO="${GITHUB_REPOSITORY}"
+
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --repo "$REPO" --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --repo "$REPO" \
+              --title "$TAG" \
+              --generate-notes \
+              --verify-tag \
+              --prerelease
+          fi
+
+  github_release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [publish_pypi]
+    if: >
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: dist
+          path: dist
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          REPO="${GITHUB_REPOSITORY}"
+
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --repo "$REPO" --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --repo "$REPO" \
+              --title "$TAG" \
+              --generate-notes \
+              --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 0.2.0 - 2026-04-18
+
+### Added
+
+- Tag-driven release automation for TestPyPI, PyPI, and GitHub Releases.
+- Release metadata validation via `scripts/check_release_version.py`.
+- State-schema compatibility tests backed by a pinned serialized-state fixture.
+
+### Changed
+
+- The package version is now single-source in `pyproject.toml`.
+- `tsconformal.__version__` now prefers installed package metadata and falls
+  back to `pyproject.toml` during direct source-tree execution.
+- Packaging metadata now uses an SPDX license expression with an explicit
+  tracked license file.
+- Serialized calibrator state now uses an explicit schema-version allowlist
+  that is independent of the package version.
+- The public docs and installation instructions now reflect the PyPI release
+  channel and the new release process.
+
+### Fixed
+
+- Local setup output now derives the installed package version at runtime
+  instead of printing a hard-coded string.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: Dara
 repository-code: https://github.com/daradehghan/segmented-conformal-transport
 license: MIT
-version: 0.1.0
-date-released: 2026-03-30
+version: 0.2.0
+date-released: 2026-04-18
 abstract: >
   Segmented Conformal Transport for one-step predictive CDF recalibration
   under nonstationarity.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The raw benchmark input sources and expected local filenames are recorded in `da
 
 ## Installation
 
+Published releases install from PyPI.
+
+```bash
+pip install tsconformal
+```
+
 The editable install below matches the development environment.
 
 ```bash

--- a/benchmarks/baselines.py
+++ b/benchmarks/baselines.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from collections import deque
 
 import numpy as np
-from scipy.stats import norm
 
 
 class ACIBaseline:

--- a/benchmarks/run_real_data.py
+++ b/benchmarks/run_real_data.py
@@ -163,11 +163,11 @@ def run_aci_on_cached(
     for t, fc in enumerate(forecasts):
         idx = t - eval_start
         y_hat = np.median(fc["quantiles"])
-        l, u = aci.predict_interval(y_hat)
+        lower, upper = aci.predict_interval(y_hat)
         if idx >= 0:
             y_true[idx] = fc["y_true"]
-            lo[idx] = l
-            hi[idx] = u
+            lo[idx] = lower
+            hi[idx] = upper
         aci.update(fc["y_true"], y_hat)
     return {
         "method": "ACI",
@@ -553,7 +553,7 @@ def run_benchmark(pit_seed: int = DEFAULT_PIT_SEED) -> None:
             .median()
             .round(4)
         )
-        print(f"\n=== HEADLINE TABLE ===", flush=True)
+        print("\n=== HEADLINE TABLE ===", flush=True)
         print(summary.to_string(), flush=True)
 
 

--- a/benchmarks/run_synthetic.py
+++ b/benchmarks/run_synthetic.py
@@ -8,18 +8,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import warnings
 import time
-from dataclasses import dataclass, field
+import warnings
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 
 import numpy as np
-from scipy.stats import norm
 
-from tsconformal import (
-    QuantileGridCDFAdapter,
-)
 from tsconformal._benchmark_defaults import (
     DEFAULT_PIT_SEED,
     build_sct_calibrator,
@@ -29,11 +25,9 @@ from tsconformal.metrics import (
     gridwise_calibration_error,
     marginal_coverage,
     mean_interval_width,
-    adaptation_lag,
 )
 from tsconformal.diagnostics import (
     pit_uniformity_tests,
-    rolling_coverage,
     warm_start_occupancy,
 )
 from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
@@ -195,8 +189,10 @@ def run_aci(stream: SyntheticStream, alpha: float = 0.10) -> MethodResult:
         y_hat = stream.forecast_mu[t]  # point forecast = miscalibrated mean
         l90, u90 = aci_90.predict_interval(y_hat)
         l80, u80 = aci_80.predict_interval(y_hat)
-        lowers_90[t] = l90; uppers_90[t] = u90
-        lowers_80[t] = l80; uppers_80[t] = u80
+        lowers_90[t] = l90
+        uppers_90[t] = u90
+        lowers_80[t] = l80
+        uppers_80[t] = u80
         aci_90.update(stream.y[t], y_hat)
         aci_80.update(stream.y[t], y_hat)
 
@@ -243,8 +239,10 @@ def run_split_cp(stream: SyntheticStream, alpha: float = 0.10,
         y_hat = stream.forecast_mu[test_start + t]
         l90, u90 = cp_90.predict_interval(y_hat)
         l80, u80 = cp_80.predict_interval(y_hat)
-        lowers_90[t] = l90; uppers_90[t] = u90
-        lowers_80[t] = l80; uppers_80[t] = u80
+        lowers_90[t] = l90
+        uppers_90[t] = u90
+        lowers_80[t] = l80
+        uppers_80[t] = u80
 
     y_test = stream.y[test_start:]
     cov_90 = marginal_coverage(y_test, lowers_90, uppers_90)
@@ -281,8 +279,8 @@ def get_scenarios() -> List[dict]:
     for lam in [0.0, 0.2, 0.4]:
         scenarios.append({
             "name": f"B: L=1000, λ={lam}",
-            "gen": lambda s, l=lam: generate_family_B(
-                L=1000, lambda_r=l, phi=0.5, seed=s),
+            "gen": lambda seed, drift=lam: generate_family_B(
+                L=1000, lambda_r=drift, phi=0.5, seed=seed),
         })
 
     # Family C: abrupt change
@@ -297,8 +295,8 @@ def get_scenarios() -> List[dict]:
     for ls in [25, 100]:
         scenarios.append({
             "name": f"D: L_short={ls}",
-            "gen": lambda s, l=ls: generate_family_D(
-                L_short=l, phi=0.5, T_scored=3000, seed=s),
+            "gen": lambda seed, short_length=ls: generate_family_D(
+                L_short=short_length, phi=0.5, T_scored=3000, seed=seed),
         })
 
     # Family F: heavy tails

--- a/benchmarks/synthetic/dgp.py
+++ b/benchmarks/synthetic/dgp.py
@@ -11,11 +11,11 @@ G. Gradually drifting forecaster
 """
 
 from __future__ import annotations
-from dataclasses import dataclass, field, replace
-from typing import List, Tuple
+
+from dataclasses import dataclass, replace
+from typing import List
 
 import numpy as np
-from scipy.stats import norm, t as t_dist
 
 
 @dataclass
@@ -162,8 +162,6 @@ def generate_family_C(
     sigma_hat = np.ones(T_total)
     regime_ids = np.zeros(T_total, dtype=int)
 
-    # Regime 0: well-calibrated
-    s0 = T_burn
     # Regime 1: jump
     s1 = T_burn + L
     mu_hat[s1:s1 + L] = Delta_b

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,4 @@ Companion paper (preprint DOI): https://doi.org/10.13140/RG.2.2.28984.30723
 
 ## Version
 
-Current release: v0.1.0
+This documentation tracks `tsconformal` v0.2.0.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,11 +2,15 @@
 
 ## Installation
 
-The current public release installs from source.
+Published releases install from PyPI.
 
 ```bash
-pip install .
-# or for development:
+pip install tsconformal
+```
+
+For local development, install from a checkout.
+
+```bash
 pip install -e .
 ```
 
@@ -79,3 +83,7 @@ save_calibrator(cal, "state.zip")       # zip bundle
 # Load and continue
 cal_resumed = load_calibrator("path/to/state", step_schedule=step_schedule)
 ```
+
+Serialized calibrator state has its own schema version. We change that schema
+only when the persisted layout or its semantics change, not on every package
+release.

--- a/docs/theory_alignment.md
+++ b/docs/theory_alignment.md
@@ -1,6 +1,6 @@
 # Theory Alignment
 
-This document maps `tsconformal` v0.1.0 to the verified theory in *Conformal Calibration under Nonstationarity*.
+This document maps `tsconformal` v0.2.0 to the verified theory in *Conformal Calibration under Nonstationarity*.
 
 ## Theorem scope
 
@@ -50,3 +50,9 @@ The theory assumes access to a true CDF. When using `QuantileGridCDFAdapter`:
 - `cdf(y)` is the right-continuous inverse, with `cdf_left(y)` used for randomized PIT
 - Extrapolation uses nearest non-zero slope, clipped to [0,1]
 - This is an adapter-defined pseudo-CDF, not a model-native analytic CDF
+
+## Serialized state
+
+Serialized calibrator state follows a separate compatibility contract. The
+package version changes with each public release, while the state schema changes
+only when the persisted layout or its semantics change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,45 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsconformal"
-version = "0.1.0"
+version = "0.2.0"
 description = "Segmented Conformal Transport for predictive CDF recalibration under nonstationarity"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11,<3.13"
+authors = [
+    {name = "Dara Dehghan"},
+]
+maintainers = [
+    {name = "Dara Dehghan"},
+]
+keywords = [
+    "conformal prediction",
+    "time series",
+    "calibration",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "numpy>=1.24",
     "scipy>=1.11",
     "pandas>=2.0",
     "typing_extensions>=4.5",
 ]
+
+[project.urls]
+Homepage = "https://github.com/daradehghan/segmented-conformal-transport"
+Repository = "https://github.com/daradehghan/segmented-conformal-transport"
+Issues = "https://github.com/daradehghan/segmented-conformal-transport/issues"
+Documentation = "https://github.com/daradehghan/segmented-conformal-transport/tree/main/docs"
 
 [project.optional-dependencies]
 plots = ["matplotlib>=3.7", "statsmodels>=0.14"]
@@ -30,6 +55,10 @@ dev = [
     "pytest-cov>=4.1",
     "mypy>=1.5",
     "ruff>=0.1",
+    "build>=1.2",
+    "twine>=5",
+    "packaging>=23",
+    "PyYAML>=6",
 ]
 
 [tool.setuptools.packages.find]

--- a/reproducibility/tsconformal_benchmark_colab.ipynb
+++ b/reproducibility/tsconformal_benchmark_colab.ipynb
@@ -253,16 +253,18 @@
    },
    "outputs": [],
    "source": [
-    "import torch, numpy as np\n",
-    "print(f\"GPU: {torch.cuda.get_device_name(0)}\")\n",
-    "\n",
+    "import numpy as np\n",
+    "import torch\n",
     "from chronos import Chronos2Pipeline\n",
+    "\n",
+    "print(f\"GPU: {torch.cuda.get_device_name(0)}\")\n",
     "pipeline = Chronos2Pipeline.from_pretrained('amazon/chronos-2', device_map='auto')\n",
     "ctx = torch.tensor(np.random.randn(100).astype(np.float32))\n",
     "q, _ = pipeline.predict_quantiles([ctx], prediction_length=1, quantile_levels=[0.1, 0.5, 0.9], batch_size=1)\n",
     "print(f'Output: {q[0].detach().cpu().numpy().flatten()}')\n",
     "print('✓ Chronos-2 OK')\n",
-    "del pipeline; torch.cuda.empty_cache()"
+    "del pipeline\n",
+    "torch.cuda.empty_cache()"
    ]
   },
   {

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -1,0 +1,230 @@
+"""Validate package metadata for release and dry-run workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+import tomllib
+
+from packaging.version import InvalidVersion, Version
+import yaml
+
+STRICT_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(rc\d+)?$")
+
+
+class ReleaseVersionError(ValueError):
+    """Raised when release metadata violates the repo policy."""
+
+
+@dataclass(frozen=True)
+class ReleaseCheckResult:
+    """Hold the validated metadata needed by the release workflow."""
+
+    version: str
+    parsed_version: Version
+    tag: str
+    is_prerelease: bool
+    release_mode: bool
+
+
+def set_output(name: str, value: str) -> None:
+    """Write a GitHub Actions step output when the runner requests it."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def validate_version_string(raw_version: str, label: str) -> Version:
+    """Require the repo's raw version policy and packaging semantics."""
+    if not STRICT_RELEASE_VERSION_RE.fullmatch(raw_version):
+        raise ReleaseVersionError(
+            f"{label} {raw_version!r} does not match the supported release forms "
+            "'X.Y.Z' or 'X.Y.ZrcN'."
+        )
+    try:
+        return Version(raw_version)
+    except InvalidVersion as exc:
+        raise ReleaseVersionError(
+            f"{label} {raw_version!r} is not a valid Python package version."
+        ) from exc
+
+
+def read_project_version(pyproject_path: Path) -> tuple[str, Version]:
+    """Read the canonical package version from pyproject metadata."""
+    with pyproject_path.open("rb") as handle:
+        data = tomllib.load(handle)
+    try:
+        raw_version = str(data["project"]["version"])
+    except KeyError as exc:
+        raise ReleaseVersionError(
+            "pyproject.toml is missing [project].version."
+        ) from exc
+    return raw_version, validate_version_string(raw_version, "Project version")
+
+
+def read_citation_version(citation_path: Path) -> str:
+    """Read the citation version from CITATION.cff."""
+    with citation_path.open(encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict) or "version" not in data:
+        raise ReleaseVersionError("CITATION.cff is missing a top-level version field.")
+    return str(data["version"])
+
+
+def require_matching_citation_version(
+    citation_path: Path,
+    raw_project_version: str,
+    project_version: Version,
+) -> None:
+    """Require CITATION.cff to agree with the package version."""
+    citation_raw = read_citation_version(citation_path)
+    try:
+        citation_version = Version(citation_raw)
+    except InvalidVersion as exc:
+        raise ReleaseVersionError(
+            f"CITATION.cff version {citation_raw!r} is not a valid Python package "
+            "version."
+        ) from exc
+    if citation_version != project_version:
+        raise ReleaseVersionError(
+            f"CITATION.cff version {citation_raw!r} does not match "
+            f"pyproject.toml version {raw_project_version!r}."
+        )
+
+
+def changelog_has_entry(changelog_path: Path, version: str) -> bool:
+    """Return True when CHANGELOG.md has a heading for the given version."""
+    content = changelog_path.read_text(encoding="utf-8")
+    pattern = re.compile(rf"^##\s+{re.escape(version)}\b", re.MULTILINE)
+    return pattern.search(content) is not None
+
+
+def require_changelog_entry(changelog_path: Path, version: str) -> None:
+    """Require CHANGELOG.md to contain a release heading for the version."""
+    if not changelog_path.exists():
+        raise ReleaseVersionError(
+            "CHANGELOG.md must exist before automated public releases."
+        )
+    if not changelog_has_entry(changelog_path, version):
+        raise ReleaseVersionError(
+            f"CHANGELOG.md does not contain an entry for version {version!r}."
+        )
+
+
+def check_release_version(
+    repo_root: Path,
+    *,
+    event_name: str | None = None,
+    ref_name: str | None = None,
+) -> ReleaseCheckResult:
+    """Validate release metadata for tag pushes and manual dry runs."""
+    pyproject_path = repo_root / "pyproject.toml"
+    citation_path = repo_root / "CITATION.cff"
+    changelog_path = repo_root / "CHANGELOG.md"
+
+    raw_project_version, parsed_project_version = read_project_version(pyproject_path)
+    release_mode = event_name == "push" and bool(ref_name) and ref_name.startswith("v")
+
+    tag = ""
+    if release_mode:
+        tag = str(ref_name)
+        if not tag.startswith("v"):
+            raise ReleaseVersionError(
+                f"Release tag {tag!r} must start with the 'v' prefix."
+            )
+        raw_tag_version = tag[1:]
+        parsed_tag_version = validate_version_string(raw_tag_version, "Tag version")
+        if parsed_tag_version != parsed_project_version:
+            raise ReleaseVersionError(
+                f"Tag version {raw_tag_version!r} does not match "
+                f"pyproject.toml version {raw_project_version!r}."
+            )
+
+    if citation_path.exists():
+        require_matching_citation_version(
+            citation_path,
+            raw_project_version,
+            parsed_project_version,
+        )
+    elif release_mode:
+        raise ReleaseVersionError(
+            "CITATION.cff must exist for tag-based release validation."
+        )
+
+    if release_mode:
+        require_changelog_entry(changelog_path, raw_project_version)
+    elif changelog_path.exists() and not changelog_has_entry(
+        changelog_path, raw_project_version
+    ):
+        print(
+            f"CHANGELOG.md does not yet contain an entry for version "
+            f"{raw_project_version!r}.",
+        )
+
+    return ReleaseCheckResult(
+        version=raw_project_version,
+        parsed_version=parsed_project_version,
+        tag=tag,
+        is_prerelease=parsed_project_version.is_prerelease,
+        release_mode=release_mode,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line options for local and CI invocation."""
+    parser = argparse.ArgumentParser(
+        description="Validate package metadata for release workflows."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root containing pyproject.toml.",
+    )
+    parser.add_argument(
+        "--event-name",
+        type=str,
+        default=None,
+        help="Workflow event name. Defaults to GITHUB_EVENT_NAME.",
+    )
+    parser.add_argument(
+        "--ref-name",
+        type=str,
+        default=None,
+        help="Workflow ref name. Defaults to GITHUB_REF_NAME.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release guard and emit step outputs for GitHub Actions."""
+    args = parse_args(argv)
+    event_name = args.event_name or os.environ.get("GITHUB_EVENT_NAME")
+    ref_name = args.ref_name or os.environ.get("GITHUB_REF_NAME")
+    result = check_release_version(
+        args.repo_root,
+        event_name=event_name,
+        ref_name=ref_name,
+    )
+
+    set_output("version", result.version)
+    set_output("tag", result.tag)
+    set_output("is_prerelease", str(result.is_prerelease).lower())
+
+    if result.release_mode:
+        print(
+            f"Validated release tag {result.tag!r} against package version "
+            f"{result.version!r}."
+        )
+    else:
+        print(f"Validated package version {result.version!r} for dry-run mode.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup_and_test.sh
+++ b/setup_and_test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
 
-echo "=== tsconformal v0.1.0 setup ==="
+echo "=== tsconformal setup ==="
 
 # 1. Create virtual environment
 echo "[1/5] Creating virtual environment..."
@@ -21,6 +21,7 @@ pip install --upgrade pip --quiet
 # 3. Install package + dev dependencies
 echo "[3/5] Installing tsconformal + dev dependencies..."
 pip install -e ".[dev,plots]" --quiet
+echo "Installed tsconformal version: $(python -c 'import tsconformal; print(tsconformal.__version__)')"
 
 # 4. Run tests
 echo "[4/5] Running tests..."

--- a/src/tsconformal/__init__.py
+++ b/src/tsconformal/__init__.py
@@ -1,33 +1,26 @@
-"""tsconformal — Segmented Conformal Transport for predictive CDF recalibration.
+"""Segmented Conformal Transport for predictive CDF recalibration."""
 
-This package implements the SCT algorithm from the paper
-"Conformal Calibration under Nonstationarity" with a public API
-matching Appendix D of the verified manuscript.
+from __future__ import annotations
 
-Quick start::
+from importlib.metadata import PackageNotFoundError, version as _metadata_version
+from pathlib import Path
+import tomllib
 
-    from tsconformal import (
-        SegmentedTransportCalibrator,
-        CUSUMNormDetector,
-        QuantileGridCDFAdapter,
-    )
 
-    detector = CUSUMNormDetector(kappa=0.02, threshold=0.20)
-    cal = SegmentedTransportCalibrator(
-        grid_size=49,
-        rho=0.99,
-        n_eff_min=50,
-        step_schedule=lambda n: min(0.20, 1.0 / n**0.5),
-        detector=detector,
-        cooldown=168,
-        confirm=3,
-    )
+def _read_source_tree_version() -> str:
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    try:
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+        version = data["project"]["version"]
+    except Exception:
+        return "0.0.0+unknown"
+    return str(version)
 
-    # Online loop
-    calibrated_cdf = cal.predict_cdf(base_cdf)
-    cal.update(y_t, base_cdf)
-"""
 
-__version__ = "0.1.0"
+try:
+    __version__ = _metadata_version("tsconformal")
+except PackageNotFoundError:
+    __version__ = _read_source_tree_version()
 
-from tsconformal.api import *  # noqa: F401, F403
+from tsconformal.api import *  # noqa: E402, F401, F403

--- a/src/tsconformal/calibrators.py
+++ b/src/tsconformal/calibrators.py
@@ -692,7 +692,7 @@ def save_calibrator(
     array_bytes = b""
     if arrays:
         buf = io.BytesIO()
-        np.savez_compressed(buf, **arrays)
+        np.savez_compressed(cast(Any, buf), **arrays)
         array_bytes = buf.getvalue()
 
     if path.suffix == ".zip":

--- a/src/tsconformal/calibrators.py
+++ b/src/tsconformal/calibrators.py
@@ -679,7 +679,7 @@ def save_calibrator(
     state = calibrator._get_state()
 
     # Separate arrays from metadata
-    arrays = {}
+    arrays: dict[str, np.ndarray[Any, Any]] = {}
     meta = {}
     for k, v in state.items():
         if isinstance(v, (list,)) and len(v) > 10:
@@ -692,7 +692,7 @@ def save_calibrator(
     array_bytes = b""
     if arrays:
         buf = io.BytesIO()
-        np.savez_compressed(cast(Any, buf), **arrays)
+        np.savez_compressed(cast(Any, buf), **cast(Any, arrays))
         array_bytes = buf.getvalue()
 
     if path.suffix == ".zip":

--- a/src/tsconformal/calibrators.py
+++ b/src/tsconformal/calibrators.py
@@ -12,7 +12,7 @@ import json
 import warnings
 from collections import deque
 from pathlib import Path
-from typing import Any, Callable, List, Literal, Mapping, Optional
+from typing import Any, Callable, List, Literal, Optional
 
 import numpy as np
 from scipy.stats import ks_2samp
@@ -26,7 +26,6 @@ from tsconformal.forecast import (
 from tsconformal.utils import (
     build_transport_map,
     clip_cdf,
-    clip_probability,
     ensure_rng,
     pav_isotonic,
 )
@@ -122,9 +121,18 @@ def _default_step(n: float) -> float:
     return min(0.20, 1.0 / max(np.sqrt(n), 1e-8))
 
 
+def _identity_transport(u):
+    return u
+
+
 _TAIL_LEN = 256
 _DEFAULT_STEP_SCHEDULE_ID = "__default__"
 _CUSTOM_STEP_SCHEDULE_ID = "__custom__"
+
+# Serialized state has its own compatibility contract. The package version may
+# advance without changing the persisted layout.
+STATE_SCHEMA_VERSION = "0.1.0"
+SUPPORTED_STATE_SCHEMA_VERSIONS = {STATE_SCHEMA_VERSION}
 
 
 def _resolve_step_schedule_id(step_schedule: Callable[[float], float]) -> str:
@@ -137,6 +145,16 @@ def _resolve_step_schedule_id(step_schedule: Callable[[float], float]) -> str:
         return str(schedule_id)
 
     return _CUSTOM_STEP_SCHEDULE_ID
+
+
+def _validate_state_schema_version(state_schema_version: Any) -> str:
+    """Accept only explicit schema versions that we know how to load."""
+    if state_schema_version not in SUPPORTED_STATE_SCHEMA_VERSIONS:
+        raise ValueError(
+            f"Unsupported state schema version {state_schema_version!r}; "
+            f"supported versions are {sorted(SUPPORTED_STATE_SCHEMA_VERSIONS)!r}."
+        )
+    return str(state_schema_version)
 
 
 class SegmentedTransportCalibrator:
@@ -196,13 +214,25 @@ class SegmentedTransportCalibrator:
         if confirm < 1:
             raise ValueError("confirm must be >= 1")
         if projection != "isotonic_l2":
-            raise ValueError(f"unsupported projection: {projection!r}; v0.1 supports only 'isotonic_l2'")
+            raise ValueError(
+                f"unsupported projection: {projection!r}; only 'isotonic_l2' "
+                "is supported."
+            )
         if interpolation != "piecewise_linear":
-            raise ValueError(f"unsupported interpolation: {interpolation!r}; v0.1 supports only 'piecewise_linear'")
+            raise ValueError(
+                f"unsupported interpolation: {interpolation!r}; only "
+                "'piecewise_linear' is supported."
+            )
         if fallback != "identity":
-            raise ValueError(f"unsupported fallback: {fallback!r}; v0.1 supports only 'identity'")
+            raise ValueError(
+                f"unsupported fallback: {fallback!r}; only 'identity' is "
+                "supported."
+            )
         if warm_start != "identity":
-            raise ValueError(f"unsupported warm_start: {warm_start!r}; v0.1 supports only 'identity'")
+            raise ValueError(
+                f"unsupported warm_start: {warm_start!r}; only 'identity' is "
+                "supported."
+            )
 
         self._grid_size = grid_size
         self._rho = rho
@@ -324,7 +354,7 @@ class SegmentedTransportCalibrator:
         base_cdf : ForecastCDF
             Base forecast for the current time step.
         x_t : ignored
-            Placeholder for covariates (unused in v0.1).
+            Placeholder for covariates (unused in the current implementation).
 
         Returns
         -------
@@ -351,8 +381,8 @@ class SegmentedTransportCalibrator:
         self._last_predict_t = self._t
 
         if self._in_fallback:
-            T = lambda u: u
-            T_inv = lambda u: u
+            T = _identity_transport
+            T_inv = _identity_transport
         else:
             T, T_inv = build_transport_map(self._grid, self._g)
 
@@ -556,7 +586,7 @@ class SegmentedTransportCalibrator:
     def _get_state(self) -> dict:
         """Return full internal state as a serializable dict."""
         return {
-            "schema_version": "0.1.0",
+            "schema_version": STATE_SCHEMA_VERSION,
             "grid_size": self._grid_size,
             "rho": self._rho,
             "n_eff_min": self._n_eff_min,
@@ -592,10 +622,7 @@ class SegmentedTransportCalibrator:
 
     def _set_state(self, state: dict) -> None:
         """Restore internal state from a dict."""
-        if state.get("schema_version") != "0.1.0":
-            raise ValueError(
-                f"Incompatible schema version: {state.get('schema_version')}"
-            )
+        _validate_state_schema_version(state.get("schema_version"))
         self._t = state["t"]
         self._segment_id = state["segment_id"]
         self._num_resets = state["num_resets"]
@@ -741,10 +768,7 @@ def load_calibrator(
         state[k] = v.tolist()
 
     # Validate schema
-    if state.get("schema_version") != "0.1.0":
-        raise ValueError(
-            f"Incompatible schema version: {state.get('schema_version')}"
-        )
+    _validate_state_schema_version(state.get("schema_version"))
 
     # Reconstruct detector
     det_state = state.get("detector_state", {})

--- a/src/tsconformal/calibrators.py
+++ b/src/tsconformal/calibrators.py
@@ -12,7 +12,7 @@ import json
 import warnings
 from collections import deque
 from pathlib import Path
-from typing import Any, Callable, List, Literal, Optional
+from typing import Any, Callable, List, Literal, Optional, cast
 
 import numpy as np
 from scipy.stats import ks_2samp
@@ -794,7 +794,7 @@ def load_calibrator(
             detector._M = det_state.get("M", 0.0)
             detector._t = det_state.get("t", 0)
         else:
-            detector = det_cls()
+            detector = cast(SegmentDetector, det_cls())
     else:
         raise ValueError(
             f"Cannot reconstruct detector type '{det_type_name}'. "

--- a/src/tsconformal/diagnostics.py
+++ b/src/tsconformal/diagnostics.py
@@ -8,7 +8,7 @@ by the benchmarks and diagnostics workflow.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Optional
 import warnings
 
 import numpy as np

--- a/src/tsconformal/diagnostics.py
+++ b/src/tsconformal/diagnostics.py
@@ -247,7 +247,11 @@ def sensitivity_report(
         Summary of metrics across configurations.
     """
     from tsconformal._benchmark_defaults import build_sct_calibrator, make_pit_rng
-    from tsconformal.detectors import CUSUMNormDetector, PageHinkleyDetector
+    from tsconformal.detectors import (
+        CUSUMNormDetector,
+        PageHinkleyDetector,
+        SegmentDetector,
+    )
     from tsconformal.forecast import InvalidForecastCDFError
 
     # Materialize the stream once (needed for re-running per config)
@@ -260,6 +264,7 @@ def sensitivity_report(
     for config in detector_grid:
         pit_rng = make_pit_rng(pit_seed)
         # Build detector from config
+        det: SegmentDetector
         if config.detector_type == "CUSUMNorm":
             det = CUSUMNormDetector(
                 kappa=config.kappa, threshold=config.threshold
@@ -321,8 +326,12 @@ def sensitivity_report(
     # Detect shopping risk: high variability in reset counts
     if len(report.results) > 1:
         reset_counts = [r.n_resets for r in report.results]
+        reset_counts_array = np.asarray(reset_counts, dtype=np.float64)
         rc_range = max(reset_counts) - min(reset_counts)
-        rc_cv = float(np.std(reset_counts) / max(np.mean(reset_counts), 1e-8))
+        mean_reset_count = float(np.mean(reset_counts_array))
+        rc_cv = float(
+            np.std(reset_counts_array) / max(mean_reset_count, 1e-8)
+        )
         report.detector_shopping_risk = rc_cv > 0.5
         report.variability_summary = {
             "reset_count_range": float(rc_range),

--- a/src/tsconformal/examples/chronos_wrapper_example.py
+++ b/src/tsconformal/examples/chronos_wrapper_example.py
@@ -79,7 +79,7 @@ def run_example(seed: int = 42, T: int = 500):
         try:
             base_cdf = QuantileGridCDFAdapter(probabilities=Q, quantiles=quantiles)
             validate_forecast_cdf(base_cdf)
-        except (InvalidForecastCDFError, Exception) as e:
+        except (InvalidForecastCDFError, Exception):
             # Skip-and-log policy: do not replace with fallback
             fm_failures += 1
             continue

--- a/src/tsconformal/examples/rolling_evaluation.py
+++ b/src/tsconformal/examples/rolling_evaluation.py
@@ -40,7 +40,9 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
         return GaussianForecastCDF(mu=0.3, sigma=0.8)
 
     # Create calibrator
-    step_schedule = lambda n: min(0.20, 1.0 / max(n ** 0.5, 1e-8))
+    def step_schedule(n):
+        return min(0.20, 1.0 / max(n**0.5, 1e-8))
+
     detector = CUSUMNormDetector(kappa=0.02, threshold=0.20)
     cal = SegmentedTransportCalibrator(
         grid_size=19,
@@ -109,7 +111,7 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
     # Verify exact continuation
     assert_allclose(orig_predictions, loaded_predictions, atol=1e-10,
                     err_msg="Loaded calibrator diverged!")
-    print(f"\n=== Serialization verification ===")
+    print("\n=== Serialization verification ===")
     print(f"  Predictions match: YES (max diff: {np.max(np.abs(np.array(orig_predictions) - np.array(loaded_predictions))):.2e})")
     print(f"  segment_id match: {cal.segment_id == cal_loaded.segment_id}")
     print(f"  num_resets match: {cal.num_resets == cal_loaded.num_resets}")

--- a/src/tsconformal/examples/rolling_evaluation.py
+++ b/src/tsconformal/examples/rolling_evaluation.py
@@ -56,16 +56,16 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
 
     # Online loop — first half
     alpha = 0.10
-    covered = []
-    widths = []
+    covered: list[float] = []
+    widths: list[float] = []
     all_warnings = []
 
     for t in range(save_at):
         cdf = make_forecast(t)
         cal_cdf = cal.predict_cdf(cdf)
 
-        lower = cal_cdf.ppf(alpha / 2)
-        upper = cal_cdf.ppf(1.0 - alpha / 2)
+        lower = float(cal_cdf.ppf(alpha / 2))
+        upper = float(cal_cdf.ppf(1.0 - alpha / 2))
         cov = float(lower <= y_data[t] <= upper)
         covered.append(cov)
         widths.append(upper - lower)
@@ -74,9 +74,11 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
         if cal.warnings:
             all_warnings.extend(cal.warnings)
 
+    covered_array = np.asarray(covered, dtype=np.float64)
+    widths_array = np.asarray(widths, dtype=np.float64)
     print(f"=== Phase 1 (t=0..{save_at-1}) ===")
-    print(f"  Coverage: {np.mean(covered):.3f} (target: {1-alpha:.2f})")
-    print(f"  Mean width: {np.mean(widths):.3f}")
+    print(f"  Coverage: {np.mean(covered_array):.3f} (target: {1-alpha:.2f})")
+    print(f"  Mean width: {np.mean(widths_array):.3f}")
     print(f"  Resets: {cal.num_resets}")
     print(f"  Warnings collected: {len(all_warnings)}")
 
@@ -86,14 +88,14 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
     print(f"  Saved at t={save_at}")
 
     # Continue original for second half
-    orig_predictions = []
+    orig_predictions: list[float] = []
     for t in range(save_at, T):
         cdf = make_forecast(t)
         cal_cdf = cal.predict_cdf(cdf)
-        orig_predictions.append(cal_cdf.cdf(0.5))
+        orig_predictions.append(float(cal_cdf.cdf(0.5)))
 
-        lower = cal_cdf.ppf(alpha / 2)
-        upper = cal_cdf.ppf(1.0 - alpha / 2)
+        lower = float(cal_cdf.ppf(alpha / 2))
+        upper = float(cal_cdf.ppf(1.0 - alpha / 2))
         covered.append(float(lower <= y_data[t] <= upper))
         widths.append(upper - lower)
 
@@ -101,11 +103,11 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
 
     # Reload and continue
     cal_loaded = load_calibrator(save_dir, step_schedule=step_schedule)
-    loaded_predictions = []
+    loaded_predictions: list[float] = []
     for t in range(save_at, T):
         cdf = make_forecast(t)
         cal_cdf = cal_loaded.predict_cdf(cdf)
-        loaded_predictions.append(cal_cdf.cdf(0.5))
+        loaded_predictions.append(float(cal_cdf.cdf(0.5)))
         cal_loaded.update(y_data[t], cdf)
 
     # Verify exact continuation
@@ -118,12 +120,14 @@ def run_example(seed: int = 42, T: int = 600, save_at: int = 300):
     print(f"  n_eff match: {abs(cal.n_eff - cal_loaded.n_eff) < 1e-10}")
 
     # Rolling coverage
-    roll_cov = rolling_coverage(np.array(covered), window=100)
+    covered_array = np.asarray(covered, dtype=np.float64)
+    widths_array = np.asarray(widths, dtype=np.float64)
+    roll_cov = rolling_coverage(covered_array, window=100)
     valid_roll = roll_cov[~np.isnan(roll_cov)]
 
     print(f"\n=== Phase 2 (t=0..{T-1}) ===")
-    print(f"  Overall coverage: {np.mean(covered):.3f}")
-    print(f"  Mean width: {np.mean(widths):.3f}")
+    print(f"  Overall coverage: {np.mean(covered_array):.3f}")
+    print(f"  Mean width: {np.mean(widths_array):.3f}")
     print(f"  Rolling coverage MAD: {np.mean(np.abs(valid_roll - (1-alpha))):.4f}")
     print(f"  Total resets: {cal.num_resets}")
 

--- a/src/tsconformal/examples/synthetic_piecewise_stationary.py
+++ b/src/tsconformal/examples/synthetic_piecewise_stationary.py
@@ -8,7 +8,6 @@ import numpy as np
 
 from tsconformal import (
     CUSUMNormDetector,
-    QuantileGridCDFAdapter,
     SegmentedTransportCalibrator,
 )
 

--- a/src/tsconformal/examples/synthetic_piecewise_stationary.py
+++ b/src/tsconformal/examples/synthetic_piecewise_stationary.py
@@ -4,6 +4,8 @@ Demonstrates SCT on a three-regime synthetic stream with known
 miscalibration patterns.
 """
 
+from typing import TypedDict
+
 import numpy as np
 
 from tsconformal import (
@@ -12,8 +14,17 @@ from tsconformal import (
 )
 
 
+class SyntheticRegime(TypedDict):
+    """Parameters for one synthetic regime in the example stream."""
+
+    length: int
+    bias: float
+    scale: float
+
+
 class GaussianForecastCDF:
     """Simple Gaussian forecast CDF for synthetic experiments."""
+
     is_discrete = False
 
     def __init__(self, mu: float, sigma: float):
@@ -22,12 +33,17 @@ class GaussianForecastCDF:
 
     def cdf(self, y: float) -> float:
         from scipy.stats import norm
+
         return float(norm.cdf(y, self.mu, self.sigma))
 
-    def ppf(self, u: float) -> float:
+    def ppf(self, u: float | np.ndarray) -> float | np.ndarray:
         from scipy.stats import norm
-        u = np.clip(u, 1e-12, 1 - 1e-12)
-        return float(norm.ppf(u, self.mu, self.sigma))
+
+        clipped_u = np.clip(u, 1e-12, 1 - 1e-12)
+        quantiles = norm.ppf(clipped_u, self.mu, self.sigma)
+        if np.ndim(quantiles) == 0:
+            return float(quantiles)
+        return np.asarray(quantiles, dtype=np.float64)
 
 
 def run_example(seed: int = 42, T: int = 1500):
@@ -35,20 +51,20 @@ def run_example(seed: int = 42, T: int = 1500):
     rng = np.random.default_rng(seed)
 
     # Define three regimes with different miscalibration
-    regimes = [
+    regimes: list[SyntheticRegime] = [
         {"length": 500, "bias": 0.0, "scale": 1.0},   # well-calibrated
         {"length": 500, "bias": 0.5, "scale": 0.7},    # biased + overconfident
         {"length": 500, "bias": -0.3, "scale": 1.3},   # biased + underconfident
     ]
 
     # Generate data
-    ys = []
-    forecasts = []
-    oracle_regimes = []
+    ys: list[float] = []
+    forecasts: list[GaussianForecastCDF] = []
+    oracle_regimes: list[int] = []
     for r_id, regime in enumerate(regimes):
         n = regime["length"]
-        y = rng.normal(0, 1, size=n)
-        for yi in y:
+        observations = np.asarray(rng.normal(0.0, 1.0, size=n), dtype=np.float64)
+        for yi in observations:
             # Miscalibrated forecast
             f = GaussianForecastCDF(
                 mu=regime["bias"],
@@ -71,18 +87,24 @@ def run_example(seed: int = 42, T: int = 1500):
     )
 
     # Online loop
-    pit_values = []
-    warmup_flags = []
-    ws_weights = []
-    calibrated_quantiles_list = []
+    pit_values_list: list[float] = []
+    warmup_flags: list[bool] = []
+    ws_weights: list[float] = []
+    calibrated_quantiles_list: list[np.ndarray] = []
     J_eval = 99
-    eval_grid = np.array([j / (J_eval + 1) for j in range(1, J_eval + 1)])
+    eval_grid = np.array(
+        [j / (J_eval + 1) for j in range(1, J_eval + 1)],
+        dtype=np.float64,
+    )
 
     for t in range(len(ys)):
         # Predict
         cal_cdf = cal.predict_cdf(forecasts[t])
         # Record calibrated quantiles for E_r
-        cal_q = np.array([cal_cdf.ppf(u) for u in eval_grid])
+        cal_q = np.array(
+            [float(cal_cdf.ppf(float(u))) for u in eval_grid],
+            dtype=np.float64,
+        )
         calibrated_quantiles_list.append(cal_q)
         # Track diagnostics
         warmup_flags.append(cal.in_warmup)
@@ -90,10 +112,13 @@ def run_example(seed: int = 42, T: int = 1500):
         # Update
         cal.update(ys[t], forecasts[t])
         # Record calibrated PIT
-        pit_values.append(cal_cdf.cdf(ys[t]))
+        pit_values_list.append(float(cal_cdf.cdf(float(ys[t]))))
 
-    pit_values = np.array(pit_values)
-    calibrated_quantiles = np.array(calibrated_quantiles_list)
+    pit_values = np.asarray(pit_values_list, dtype=np.float64)
+    calibrated_quantiles = np.asarray(
+        calibrated_quantiles_list,
+        dtype=np.float64,
+    )
 
     # Summary
     print(f"Total timestamps: {len(ys)}")

--- a/src/tsconformal/forecast.py
+++ b/src/tsconformal/forecast.py
@@ -421,7 +421,7 @@ def validate_forecast_cdf(cdf: ForecastCDF) -> None:
     5. Monotonicity of cdf on probe values.
     """
     # Check ppf on probes
-    probe_values = []
+    probe_values_list: list[float] = []
     for u in _PROBE_PROBS:
         try:
             val = cdf.ppf(float(u))
@@ -429,11 +429,19 @@ def validate_forecast_cdf(cdf: ForecastCDF) -> None:
             raise InvalidForecastCDFError(
                 f"ppf({u}) raised {type(exc).__name__}: {exc}"
             ) from exc
-        if not np.isfinite(val):
-            raise InvalidForecastCDFError(f"ppf({u}) returned non-finite: {val}")
-        probe_values.append(val)
+        val_array = np.asarray(val, dtype=np.float64)
+        if val_array.ndim != 0:
+            raise InvalidForecastCDFError(
+                f"ppf({u}) returned non-scalar output for scalar input"
+            )
+        probe_value = float(val_array)
+        if not np.isfinite(probe_value):
+            raise InvalidForecastCDFError(
+                f"ppf({u}) returned non-finite: {probe_value}"
+            )
+        probe_values_list.append(probe_value)
 
-    probe_values = np.array(probe_values)
+    probe_values = np.array(probe_values_list, dtype=np.float64)
 
     # Check degenerate range
     qrange = probe_values[-1] - probe_values[0]

--- a/src/tsconformal/metrics.py
+++ b/src/tsconformal/metrics.py
@@ -45,7 +45,6 @@ def gridwise_calibration_error(
     """
     y = np.asarray(y)
     Q = np.asarray(calibrated_quantiles)
-    n = len(y)
     grid = np.array([j / (J_eval + 1) for j in range(1, J_eval + 1)])
 
     # Indicators: (n, J_eval)

--- a/src/tsconformal/plots.py
+++ b/src/tsconformal/plots.py
@@ -130,8 +130,11 @@ def lag_vs_width(
     plt = _get_plt()
     if ax is None:
         _, ax = plt.subplots()
-    max_lag = max(l for l in adaptation_lags if l is not None) * 1.2 if any(
-        l is not None for l in adaptation_lags) else 100
+    max_lag = (
+        max(lag_value for lag_value in adaptation_lags if lag_value is not None) * 1.2
+        if any(lag_value is not None for lag_value in adaptation_lags)
+        else 100
+    )
     for i, name in enumerate(method_names):
         lag = adaptation_lags[i] if adaptation_lags[i] is not None else max_lag
         marker = "o" if adaptation_lags[i] is not None else "x"

--- a/tests/fixtures/state_schema_0_1_0/meta.json
+++ b/tests/fixtures/state_schema_0_1_0/meta.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "0.1.0",
+  "grid_size": 5,
+  "rho": 0.95,
+  "n_eff_min": 2.0,
+  "cooldown": 3,
+  "confirm": 1,
+  "projection": "isotonic_l2",
+  "interpolation": "piecewise_linear",
+  "fallback": "identity",
+  "warm_start": "identity",
+  "step_schedule_id": "__default__",
+  "t": 0,
+  "segment_id": 0,
+  "num_resets": 0,
+  "last_reset_t": 0,
+  "segment_start": 0,
+  "W": 0.0,
+  "W2": 0.0,
+  "N": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+  ],
+  "m": [
+    0.16666666666666666,
+    0.3333333333333333,
+    0.5,
+    0.6666666666666666,
+    0.8333333333333334
+  ],
+  "g": [
+    0.16666666666666666,
+    0.3333333333333333,
+    0.5,
+    0.6666666666666666,
+    0.8333333333333334
+  ],
+  "grid": [
+    0.16666666666666666,
+    0.3333333333333333,
+    0.5,
+    0.6666666666666666,
+    0.8333333333333334
+  ],
+  "confirm_count": 0,
+  "in_fallback": true,
+  "warm_start_mass": 1.0,
+  "detector_type": "CUSUMNormDetector",
+  "detector_module": "tsconformal.detectors",
+  "detector_state": {
+    "kappa": 0.02,
+    "threshold": 0.2,
+    "S": 0.0,
+    "t": 0
+  },
+  "pit_history": [],
+  "residual_history": [],
+  "reset_times": [],
+  "warnings": []
+}

--- a/tests/property/test_hypothesis.py
+++ b/tests/property/test_hypothesis.py
@@ -33,7 +33,12 @@ except ImportError:
             return f
         return dec
 
-    settings = lambda **kw: lambda f: f
+    def settings(**kw):
+        def decorator(func):
+            return func
+
+        return decorator
+
     st = None
 
     def assume(x):

--- a/tests/regression/test_release_version.py
+++ b/tests/regression/test_release_version.py
@@ -1,0 +1,157 @@
+import textwrap
+
+import pytest
+
+from scripts.check_release_version import (
+    ReleaseVersionError,
+    check_release_version,
+    main,
+    validate_version_string,
+)
+
+
+def _write_release_files(
+    repo_root,
+    *,
+    version: str = "0.2.0",
+    citation_version: str | None = None,
+    changelog_versions: tuple[str, ...] = ("0.2.0",),
+) -> None:
+    repo_root.joinpath("pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""
+            [project]
+            name = "tsconformal"
+            version = "{version}"
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    if citation_version is not None:
+        repo_root.joinpath("CITATION.cff").write_text(
+            textwrap.dedent(
+                f"""
+                cff-version: 1.2.0
+                title: tsconformal
+                version: {citation_version}
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+    if changelog_versions:
+        changelog = ["# Changelog", ""]
+        for release_version in changelog_versions:
+            changelog.extend(
+                [
+                    f"## {release_version} - 2026-04-18",
+                    "",
+                    "### Changed",
+                    "",
+                    "- Metadata validation tightened.",
+                    "",
+                ]
+            )
+        repo_root.joinpath("CHANGELOG.md").write_text(
+            "\n".join(changelog),
+            encoding="utf-8",
+        )
+
+
+@pytest.mark.parametrize(
+    "raw_version",
+    ["0.2", "0.2.0.dev1", "0.2.0.post1", "0.2.0+local", "0.2.0-rc.1"],
+)
+def test_validate_version_string_rejects_disallowed_forms(raw_version):
+    with pytest.raises(ReleaseVersionError):
+        validate_version_string(raw_version, "Project version")
+
+
+def test_tag_push_requires_matching_version_metadata(tmp_path):
+    _write_release_files(tmp_path, version="0.2.0", citation_version="0.2.0")
+
+    result = check_release_version(
+        tmp_path,
+        event_name="push",
+        ref_name="v0.2.0",
+    )
+
+    assert result.version == "0.2.0"
+    assert result.tag == "v0.2.0"
+    assert result.is_prerelease is False
+
+
+def test_tag_push_marks_release_candidates_as_prereleases(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0rc1",
+        citation_version="0.2.0rc1",
+        changelog_versions=("0.2.0rc1",),
+    )
+
+    result = check_release_version(
+        tmp_path,
+        event_name="push",
+        ref_name="v0.2.0rc1",
+    )
+
+    assert result.version == "0.2.0rc1"
+    assert result.tag == "v0.2.0rc1"
+    assert result.is_prerelease is True
+
+
+def test_tag_push_rejects_mismatched_citation_version(tmp_path):
+    _write_release_files(tmp_path, version="0.2.0", citation_version="0.2.1")
+
+    with pytest.raises(ReleaseVersionError, match="CITATION.cff version"):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name="v0.2.0",
+        )
+
+
+def test_tag_push_requires_matching_changelog_entry(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0",
+        citation_version="0.2.0",
+        changelog_versions=("0.1.0",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="CHANGELOG.md does not contain"):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name="v0.2.0",
+        )
+
+
+def test_manual_dry_run_does_not_require_a_tag(tmp_path, monkeypatch):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0",
+        citation_version="0.2.0",
+        changelog_versions=(),
+    )
+    github_output = tmp_path / "github-output.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    exit_code = main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--event-name",
+            "workflow_dispatch",
+        ]
+    )
+
+    assert exit_code == 0
+    assert github_output.read_text(encoding="utf-8").splitlines() == [
+        "version=0.2.0",
+        "tag=",
+        "is_prerelease=false",
+    ]

--- a/tests/regression/test_state_schema_compatibility.py
+++ b/tests/regression/test_state_schema_compatibility.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "state_schema_0_1_0"
+
+
+def test_pinned_state_schema_fixture_loads():
+    from tsconformal import load_calibrator
+
+    calibrator = load_calibrator(FIXTURE_DIR)
+
+    assert calibrator.segment_id == 0
+    assert calibrator.num_resets == 0
+    assert calibrator.last_reset_t == 0
+    assert calibrator._grid.tolist() == pytest.approx(
+        [1.0 / 6.0, 2.0 / 6.0, 3.0 / 6.0, 4.0 / 6.0, 5.0 / 6.0]
+    )
+
+
+def test_unsupported_state_schema_versions_are_rejected(tmp_path):
+    from tsconformal import load_calibrator
+
+    state = json.loads(FIXTURE_DIR.joinpath("meta.json").read_text(encoding="utf-8"))
+    state["schema_version"] = "0.2.0"
+
+    fixture_dir = tmp_path / "unsupported-schema"
+    fixture_dir.mkdir()
+    fixture_dir.joinpath("meta.json").write_text(
+        json.dumps(state, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported state schema version"):
+        load_calibrator(fixture_dir)
+
+
+def test_serialized_state_uses_schema_constant_not_package_version(
+    tmp_path,
+    monkeypatch,
+):
+    import tsconformal
+    from tsconformal import CUSUMNormDetector, SegmentedTransportCalibrator, save_calibrator
+    from tsconformal.calibrators import STATE_SCHEMA_VERSION
+
+    monkeypatch.setattr(tsconformal, "__version__", "9.9.9", raising=False)
+
+    calibrator = SegmentedTransportCalibrator(
+        grid_size=5,
+        rho=0.95,
+        n_eff_min=2.0,
+        step_schedule=lambda n: 0.1,
+        detector=CUSUMNormDetector(),
+        cooldown=2,
+        confirm=1,
+    )
+    output_dir = tmp_path / "saved-state"
+    save_calibrator(calibrator, output_dir)
+
+    saved_state = json.loads(output_dir.joinpath("meta.json").read_text(encoding="utf-8"))
+    assert saved_state["schema_version"] == STATE_SCHEMA_VERSION
+    assert saved_state["schema_version"] != tsconformal.__version__


### PR DESCRIPTION
## Summary

- add a tag-driven release workflow with version guards, artifact reuse, TestPyPI/PyPI publish jobs, and idempotent GitHub Release creation
- harden CI with lint, permissive type-check, build validation, and wheel smoke installation while keeping CI publish-free
- make package versioning single-source in `pyproject.toml`, decouple serialized state schema versioning, and add release/state-schema regression coverage
- clear the existing repo-wide Ruff backlog that was blocking the new CI gate and fix the wheel-smoke workflow setup sequence
- update package metadata, changelog, citation metadata, docs, and setup script for the new release process

## Verification

- `python -m ruff check .`
- `python -m pytest -q tests/regression/test_release_version.py tests/regression/test_state_schema_compatibility.py`
- `python -m build --no-isolation`
- `python -m twine check --strict dist/*`
- repaired the shared `tsconformal` virtual environment so it now imports this checkout (`0.2.0`) instead of the other editable install

## Notes

- `python -m mypy --ignore-missing-imports src` still reports pre-existing errors, so type-check remains non-blocking in CI and in the release workflow
- a fully clean local wheel smoke install could not be completed in the sandbox because dependency resolution has no network access here; the GitHub CI rerun is exercising that path with the updated workflow