### PR TITLE
Prepare 0.2.0rc2 release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           path: dist
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist/
@@ -183,7 +183,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           packages-dir: dist/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0rc1 - 2026-04-19
+## 0.2.0rc2 - 2026-04-19
 
 ### Added
 
@@ -24,3 +24,6 @@
 
 - Local setup output now derives the installed package version at runtime
   instead of printing a hard-coded string.
+- Release publishing now pins `pypa/gh-action-pypi-publish` to the resolved
+  release commit so tag-based publication can pull the published container
+  image.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Dara
 repository-code: https://github.com/daradehghan/segmented-conformal-transport
 license: MIT
-version: 0.2.0rc1
+version: 0.2.0rc2
 date-released: 2026-04-19
 abstract: >
   Segmented Conformal Transport for one-step predictive CDF recalibration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsconformal"
-version = "0.2.0rc1"
+version = "0.2.0rc2"
 description = "Segmented Conformal Transport for predictive CDF recalibration under nonstationarity"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump release metadata from `0.2.0rc1` to `0.2.0rc2`
- repin `pypa/gh-action-pypi-publish` to the resolved `v1.13.0` release commit
- record the publish-action pin fix in the changelog

## Context
`v0.2.0rc1` failed in the `Publish to TestPyPI` job before upload because the previously pinned action ref resolved to a container image tag that did not exist on GHCR.

## Validation
- local release guard for `v0.2.0rc2`
- local build and `twine check --strict`
