### PR TITLE
Tighten post-release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- First public PyPI release of `tsconformal`.
 - Tag-driven release automation for TestPyPI, PyPI, and GitHub Releases.
 - Release metadata validation via `scripts/check_release_version.py`.
 - State-schema compatibility tests backed by a pinned serialized-state fixture.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the SCT reference implementation and benchmarks.
 
 Companion paper (preprint DOI): https://doi.org/10.13140/RG.2.2.28984.30723
 
+The package is now published on PyPI as `tsconformal`.
+
 ## What is included
 
 The tracked tree is deliberately compact.
@@ -38,7 +40,7 @@ The raw benchmark input sources and expected local filenames are recorded in `da
 
 ## Installation
 
-Published releases install from PyPI.
+The package now installs directly from PyPI.
 
 ```bash
 pip install tsconformal

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,4 @@ Companion paper (preprint DOI): https://doi.org/10.13140/RG.2.2.28984.30723
 
 ## Version
 
-This documentation tracks `tsconformal` v0.2.0.
+This documentation tracks the published `tsconformal` v0.2.0 release.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Published releases install from PyPI.
+The published package installs directly from PyPI.
 
 ```bash
 pip install tsconformal


### PR DESCRIPTION
## Summary
- tighten release-facing prose now that `tsconformal` 0.2.0 is live on PyPI
- make the docs index and quick start explicitly reflect the published package state
- add a changelog note for the first public PyPI release

## Validation
- `git diff --check`
- manual documentation audit after the `0.2.0` release
- local cleanup of merged release-prep branches
