### PR TITLE
Make update() fail atomically on invalid input

### DIFF
--- a/src/tsconformal/calibrators.py
+++ b/src/tsconformal/calibrators.py
@@ -20,6 +20,7 @@ from scipy.stats import ks_2samp
 from tsconformal.detectors import SegmentDetector
 from tsconformal.forecast import (
     ForecastCDF,
+    InvalidForecastCDFError,
     TransportedForecastCDF,
     validate_forecast_cdf,
 )
@@ -426,8 +427,8 @@ class SegmentedTransportCalibrator:
                 stacklevel=2,
             )
 
-        self._t += 1
-        self._warnings_list.clear()
+        if not np.isfinite(y_t):
+            raise ValueError("y_t must be finite")
 
         # Check discrete forecast without RNG
         if base_cdf.is_discrete and rng is None:
@@ -437,6 +438,13 @@ class SegmentedTransportCalibrator:
 
         # Compute PIT
         U_t = RandomizedPIT.pit(base_cdf, y_t, rng)
+        if not np.isfinite(U_t):
+            raise InvalidForecastCDFError(f"RandomizedPIT.pit returned non-finite: {U_t}")
+        if U_t < 0.0 or U_t > 1.0:
+            raise InvalidForecastCDFError(f"RandomizedPIT.pit returned out-of-range value: {U_t}")
+
+        self._t += 1
+        self._warnings_list.clear()
         self._pit_history.append(U_t)
 
         # Compute detector residuals: r_{t,j} = 1{U_t <= u_j} - g_{j}

--- a/tests/property/test_properties.py
+++ b/tests/property/test_properties.py
@@ -316,11 +316,63 @@ class TestWarningContracts:
         )
 
         cal.predict_cdf(cdf)
+        before = cal._get_state()
         with pytest.raises(
             DiscreteForecastWithoutRandomizedPITError,
             match="requires rng for randomized PIT",
         ):
             cal.update(1.0, cdf)
+        assert cal._get_state() == before
+
+    def test_non_finite_outcome_leaves_update_state_unchanged(self):
+        """Non-finite observed outcomes must be rejected atomically."""
+        import pytest
+        from tsconformal import CUSUMNormDetector, SegmentedTransportCalibrator
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cdf = GaussianForecastCDF(0.0, 1.0)
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+
+        cal.predict_cdf(cdf)
+        before = cal._get_state()
+        with pytest.raises(ValueError, match="y_t must be finite"):
+            cal.update(np.nan, cdf)
+        assert cal._get_state() == before
+
+    def test_non_finite_pit_leaves_update_state_unchanged(self, monkeypatch):
+        """Invalid PIT output must be rejected before any state mutation."""
+        import pytest
+        from tsconformal import CUSUMNormDetector, SegmentedTransportCalibrator
+        from tsconformal.calibrators import RandomizedPIT
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+        from tsconformal.forecast import InvalidForecastCDFError
+
+        cdf = GaussianForecastCDF(0.0, 1.0)
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+
+        monkeypatch.setattr(RandomizedPIT, "pit", staticmethod(lambda *_args, **_kwargs: np.nan))
+
+        cal.predict_cdf(cdf)
+        before = cal._get_state()
+        with pytest.raises(InvalidForecastCDFError, match="non-finite"):
+            cal.update(0.0, cdf)
+        assert cal._get_state() == before
 
     def test_invalid_forecast_warning_is_emitted(self):
         """Borderline invalid forecasts must emit InvalidForecastCDFWarning."""


### PR DESCRIPTION
Closes #15
Target: 0.2.1

Reorders update() so validation happens before any state mutation, and adds regression tests proving failed updates leave the calibrator unchanged.