### PR TITLE
Reject non-finite PageHinkley thresholds

### DIFF
--- a/src/tsconformal/detectors.py
+++ b/src/tsconformal/detectors.py
@@ -153,8 +153,8 @@ class PageHinkleyDetector:
     def __init__(self, delta: float = 0.01, threshold: float = 0.50):
         if not np.isfinite(delta) or delta < 0:
             raise ValueError("delta must be finite and non-negative")
-        if threshold <= 0:
-            raise ValueError("threshold must be positive")
+        if not np.isfinite(threshold) or threshold <= 0:
+            raise ValueError("threshold must be finite and positive")
         self.delta = delta
         self.threshold = threshold
         self._m: float = 0.0

--- a/tests/property/test_properties.py
+++ b/tests/property/test_properties.py
@@ -218,6 +218,15 @@ class TestNoLookahead:
         with pytest.raises(ValueError, match="delta must be finite and non-negative"):
             PageHinkleyDetector(delta=-0.01, threshold=0.5)
 
+    def test_page_hinkley_rejects_non_finite_or_non_positive_threshold(self):
+        """PageHinkleyDetector must reject invalid thresholds explicitly."""
+        import pytest
+        from tsconformal.detectors import PageHinkleyDetector
+
+        for threshold in (np.nan, np.inf, 0.0):
+            with pytest.raises(ValueError, match="threshold must be finite and positive"):
+                PageHinkleyDetector(delta=0.01, threshold=threshold)
+
     def test_cusum_rejects_non_finite_parameters(self):
         """CUSUMNormDetector must reject non-finite tuning parameters."""
         import pytest


### PR DESCRIPTION
Closes #16

Target: 0.2.1

## Summary

Tightens `PageHinkleyDetector` constructor validation so that `threshold` must be finite and positive.

Previously, non-positive thresholds were rejected, but non-finite thresholds such as `np.nan` and `np.inf` were not rejected explicitly.

## Changes

- Reject `PageHinkleyDetector(threshold=np.nan)`
- Reject `PageHinkleyDetector(threshold=np.inf)`
- Preserve rejection of `threshold <= 0`
- Update the validation message to `threshold must be finite and positive`
- Add focused regression tests for invalid threshold values

## Verification

- Focused detector tests: `3 passed`
- Ruff on edited files: passed
- Full `tests/property/test_properties.py`: `44 passed`
