### PR TITLE
Make mypy blocking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,9 @@ jobs:
         run: python -m ruff check .
 
   type-check:
-    name: Type Check (Non-Blocking)
+    name: Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
       - name: Run lint
         run: python -m ruff check .
 
-      - name: Run type check (non-blocking)
-        continue-on-error: true
+      - name: Run type check
         run: python -m mypy --ignore-missing-imports src
 
   build:


### PR DESCRIPTION
Closes #14

Target: 0.2.1

## Summary

Makes the existing mypy checks blocking in both CI and release workflows.

This keeps the current type-checking command and scope unchanged:

```bash
python -m mypy --ignore-missing-imports src
```

The goal of this PR is enforcement only, not a broader typing cleanup.

## Changes

- Rename the CI type-check job from `Type Check (Non-Blocking)` to `Type Check`
- Remove `continue-on-error: true` from the CI type-check job
- Rename the release workflow type-check step from `Run type check (non-blocking)` to `Run type check`
- Remove `continue-on-error: true` from the release workflow type-check step

## Verification

- `python -m mypy --ignore-missing-imports src`
