### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.1 - 2026-04-20
+
+Correctness and engineering hardening release.
+
+### Fixed
+
+- Made `SegmentedTransportCalibrator.update()` fail atomically when validation
+  fails.
+- Added explicit rejection of non-finite observed outcomes and invalid PIT
+  values.
+- Tightened `PageHinkleyDetector` threshold validation to require finite
+  positive thresholds.
+
+### CI
+
+- Made mypy type checking blocking in CI and release workflows.
+
 ## 0.2.0 - 2026-04-19
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: Dara
 repository-code: https://github.com/daradehghan/segmented-conformal-transport
 license: MIT
-version: 0.2.0
-date-released: 2026-04-19
+version: 0.2.1
+date-released: 2026-04-20
 abstract: >
   Segmented Conformal Transport for one-step predictive CDF recalibration
   under nonstationarity.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,4 @@ Companion paper (preprint DOI): https://doi.org/10.13140/RG.2.2.28984.30723
 
 ## Version
 
-This documentation tracks the published `tsconformal` v0.2.0 release.
+This documentation tracks the published `tsconformal` v0.2.1 release.

--- a/docs/theory_alignment.md
+++ b/docs/theory_alignment.md
@@ -1,6 +1,6 @@
 # Theory Alignment
 
-This document maps `tsconformal` v0.2.0 to the verified theory in *Conformal Calibration under Nonstationarity*.
+This document maps `tsconformal` v0.2.1 to the verified theory in *Conformal Calibration under Nonstationarity*.
 
 ## Theorem scope
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsconformal"
-version = "0.2.0"
+version = "0.2.1"
 description = "Segmented Conformal Transport for predictive CDF recalibration under nonstationarity"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Target: 0.2.1

## Summary

Prepares the `0.2.1` release after the completed correctness and CI-hardening work.

## Changes

- Bump package version to `0.2.1`
- Update `CITATION.cff` release metadata
- Add the `0.2.1` changelog entry
- Update docs version references from `v0.2.0` to `v0.2.1`

## Verification

- `python -m pytest -q`
- `python -m ruff check .`
- `python -m mypy --ignore-missing-imports src`
- `python -m build`
- `python -m twine check --strict dist/*`
- Wheel metadata confirms `Version: 0.2.1`
- sdist metadata confirms `Version: 0.2.1`
