### PR TITLE
Enforce predict/update sequencing contract

### DIFF
--- a/src/tsconformal/api.py
+++ b/src/tsconformal/api.py
@@ -17,6 +17,7 @@ from tsconformal.calibrators import (
     ExcessiveResetWarning,
     HighSerialCorrelationWarning,
     LowEffectiveSampleWarning,
+    PredictionSequenceError,
     RandomizedPIT,
     SegmentedTransportCalibrator,
     WarmStartDominanceWarning,
@@ -66,4 +67,5 @@ __all__ = [
     "WithinSegmentDriftWarning",
     "WarmStartDominanceWarning",
     "DiscreteForecastWithoutRandomizedPITError",
+    "PredictionSequenceError",
 ]

--- a/src/tsconformal/calibrators.py
+++ b/src/tsconformal/calibrators.py
@@ -60,6 +60,10 @@ class DiscreteForecastWithoutRandomizedPITError(Exception):
     """Discrete forecast used without randomized PIT support."""
 
 
+class PredictionSequenceError(RuntimeError):
+    """Invalid ``predict_cdf()``/``update()`` call sequence."""
+
+
 # -----------------------------------------------------------------------
 # RandomizedPIT
 # -----------------------------------------------------------------------
@@ -253,6 +257,7 @@ class SegmentedTransportCalibrator:
 
         # Initialize state
         self._reset_state(initial=True)
+        self._reset_prediction_sequence_state()
 
     def _reset_state(self, initial: bool = False) -> None:
         """Reset all segment-local state."""
@@ -278,6 +283,20 @@ class SegmentedTransportCalibrator:
         if initial:
             self._reset_times: deque = deque(maxlen=_TAIL_LEN)
         # Don't clear reset_times on segment reset — it's global
+
+    def _reset_prediction_sequence_state(self) -> None:
+        """Initialize transient predict/update sequencing state."""
+        self._pending_predict_cdf_id: int | None = None
+        self._pending_predict_t: int | None = None
+        self._last_consumed_predict_cdf_id: int | None = None
+        self._superseded_predict_cdf_ids: set[int] = set()
+
+    def _consume_pending_prediction(self) -> None:
+        """Mark the current pending prediction as consumed."""
+        self._last_consumed_predict_cdf_id = self._pending_predict_cdf_id
+        self._pending_predict_cdf_id = None
+        self._pending_predict_t = None
+        self._superseded_predict_cdf_ids.clear()
 
     # -------------------------------------------------------------------
     # Public properties (Appendix D diagnostics)
@@ -364,10 +383,10 @@ class SegmentedTransportCalibrator:
 
         Notes
         -----
-        The method records the identity of ``base_cdf`` and the current
-        time index so that ``update()`` can issue its heuristic
-        consistency warning when a different forecast object is supplied.
-        It does not consume ``y_t`` or change the transport map itself.
+        The method records a pending prediction for the current time step.
+        A later ``predict_cdf()`` call supersedes any earlier pending
+        prediction before ``update()`` consumes it. The method does not
+        consume ``y_t`` or change the transport map itself.
 
         Raises
         ------
@@ -377,9 +396,13 @@ class SegmentedTransportCalibrator:
         # Validate before consuming
         validate_forecast_cdf(base_cdf)
 
-        # Cache fingerprint for update consistency check
-        self._last_predict_cdf_id = id(base_cdf)
-        self._last_predict_t = self._t
+        if self._pending_predict_cdf_id is not None:
+            self._superseded_predict_cdf_ids.add(self._pending_predict_cdf_id)
+
+        pending_cdf_id = id(base_cdf)
+        self._pending_predict_cdf_id = pending_cdf_id
+        self._pending_predict_t = self._t
+        self._superseded_predict_cdf_ids.discard(pending_cdf_id)
 
         if self._in_fallback:
             T = _identity_transport
@@ -411,16 +434,46 @@ class SegmentedTransportCalibrator:
 
         Notes
         -----
-        The implementation warns when ``base_cdf`` is a different Python
-        object from the one passed to ``predict_cdf``. That is a heuristic
-        misuse check, not a full prediction-equivalence test.
+        The implementation raises ``PredictionSequenceError`` on clear
+        sequencing violations such as ``update()`` without a pending
+        prediction, repeated ``update()`` after a prediction has already
+        been consumed, or use of a superseded pending forecast. It still
+        warns on ambiguous forecast-object mismatches, because object
+        identity is only a heuristic consistency check.
         """
-        # Warn on a mismatched forecast object. This is a heuristic
-        # consistency check rather than a full prediction-equivalence test.
-        if (hasattr(self, '_last_predict_cdf_id')
-                and id(base_cdf) != self._last_predict_cdf_id):
+        base_cdf_id = id(base_cdf)
+        pending_cdf_id = self._pending_predict_cdf_id
+
+        if pending_cdf_id is None:
+            if base_cdf_id == self._last_consumed_predict_cdf_id:
+                raise PredictionSequenceError(
+                    "update() called after the pending prediction had already been "
+                    "consumed; call predict_cdf() before updating again."
+                )
+            raise PredictionSequenceError(
+                "update() called without a pending prediction; call "
+                "predict_cdf() before update()."
+            )
+
+        if base_cdf_id in self._superseded_predict_cdf_ids:
+            raise PredictionSequenceError(
+                "update() called with a superseded base_cdf; use the most "
+                f"recent forecast issued by predict_cdf() for t={self._pending_predict_t}."
+            )
+
+        if (
+            base_cdf_id == self._last_consumed_predict_cdf_id
+            and base_cdf_id != pending_cdf_id
+        ):
+            raise PredictionSequenceError(
+                "update() called with a prediction that has already been "
+                "consumed; call predict_cdf() before updating again."
+            )
+
+        if base_cdf_id != pending_cdf_id:
             warnings.warn(
-                "update() called with a different base_cdf than predict_cdf(). "
+                "update() called with a different base_cdf than predict_cdf() "
+                f"for the current pending prediction at t={self._pending_predict_t}. "
                 "Reuse the forecast used to issue the prediction; this "
                 "object-identity check is only a heuristic consistency guard.",
                 RuntimeWarning,
@@ -491,6 +544,7 @@ class SegmentedTransportCalibrator:
                 LowEffectiveSampleWarning,
                 stacklevel=2,
             )
+            self._consume_pending_prediction()
             return
 
         # Feedback smoothing: convex combination
@@ -506,6 +560,7 @@ class SegmentedTransportCalibrator:
 
         # Misuse warnings
         self._check_warnings()
+        self._consume_pending_prediction()
 
     def _do_reset(self) -> None:
         """Execute a confirmed reset."""
@@ -631,6 +686,7 @@ class SegmentedTransportCalibrator:
     def _set_state(self, state: dict) -> None:
         """Restore internal state from a dict."""
         _validate_state_schema_version(state.get("schema_version"))
+        self._reset_prediction_sequence_state()
         self._t = state["t"]
         self._segment_id = state["segment_id"]
         self._num_resets = state["num_resets"]

--- a/tests/property/test_properties.py
+++ b/tests/property/test_properties.py
@@ -545,6 +545,182 @@ class TestWarningContracts:
         ):
             cal.update(0.0, second)
 
+    def test_update_without_pending_prediction_raises(self):
+        import pytest
+
+        from tsconformal import (
+            CUSUMNormDetector,
+            PredictionSequenceError,
+            SegmentedTransportCalibrator,
+        )
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+        cdf = GaussianForecastCDF(0.0, 1.0)
+
+        with pytest.raises(
+            PredictionSequenceError,
+            match="without a pending prediction",
+        ):
+            cal.update(0.0, cdf)
+
+    def test_double_update_raises_sequence_error(self):
+        import pytest
+
+        from tsconformal import (
+            CUSUMNormDetector,
+            PredictionSequenceError,
+            SegmentedTransportCalibrator,
+        )
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+        cdf = GaussianForecastCDF(0.0, 1.0)
+
+        cal.predict_cdf(cdf)
+        cal.update(0.0, cdf)
+
+        with pytest.raises(
+            PredictionSequenceError,
+            match="already been consumed",
+        ):
+            cal.update(0.1, cdf)
+
+    def test_superseded_prediction_raises_sequence_error(self):
+        import pytest
+
+        from tsconformal import (
+            CUSUMNormDetector,
+            PredictionSequenceError,
+            SegmentedTransportCalibrator,
+        )
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+        first = GaussianForecastCDF(0.0, 1.0)
+        second = GaussianForecastCDF(0.1, 1.0)
+
+        cal.predict_cdf(first)
+        cal.predict_cdf(second)
+
+        with pytest.raises(
+            PredictionSequenceError,
+            match="superseded base_cdf",
+        ):
+            cal.update(0.0, first)
+
+    def test_latest_prediction_after_supersession_succeeds(self):
+        from tsconformal import CUSUMNormDetector, SegmentedTransportCalibrator
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+        first = GaussianForecastCDF(0.0, 1.0)
+        second = GaussianForecastCDF(0.1, 1.0)
+
+        cal.predict_cdf(first)
+        cal.predict_cdf(second)
+        cal.update(0.0, second)
+
+        assert cal._pending_predict_cdf_id is None
+        assert cal._pending_predict_t is None
+
+    def test_failed_validation_does_not_consume_pending_prediction(self):
+        import pytest
+
+        from tsconformal import (
+            CUSUMNormDetector,
+            PredictionSequenceError,
+            SegmentedTransportCalibrator,
+        )
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+        cdf = GaussianForecastCDF(0.0, 1.0)
+
+        cal.predict_cdf(cdf)
+        with pytest.raises(ValueError, match="y_t must be finite"):
+            cal.update(np.nan, cdf)
+
+        cal.update(0.0, cdf)
+
+        with pytest.raises(
+            PredictionSequenceError,
+            match="already been consumed",
+        ):
+            cal.update(0.1, cdf)
+
+    def test_consumed_prediction_raises_while_new_prediction_is_pending(self):
+        import pytest
+
+        from tsconformal import (
+            CUSUMNormDetector,
+            PredictionSequenceError,
+            SegmentedTransportCalibrator,
+        )
+        from tsconformal.examples.synthetic_piecewise_stationary import GaussianForecastCDF
+
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(kappa=0.02, threshold=10.0),
+            cooldown=100,
+            confirm=3,
+        )
+        first = GaussianForecastCDF(0.0, 1.0)
+        second = GaussianForecastCDF(0.1, 1.0)
+
+        cal.predict_cdf(first)
+        cal.update(0.0, first)
+        cal.predict_cdf(second)
+
+        with pytest.raises(
+            PredictionSequenceError,
+            match="already been consumed",
+        ):
+            cal.update(0.0, first)
+
 
 # -----------------------------------------------------------------------
 # F. Adapter extrapolation clipping
@@ -992,6 +1168,40 @@ class TestSerializationRoundTrip:
 
         cal_loaded = load_calibrator(save_path, step_schedule=step_schedule)
         assert cal_loaded._step_schedule(10.0) == step_schedule(10.0)
+
+    def test_pending_prediction_state_is_not_serialized(self, tmp_path):
+        """Loaded calibrators should not resume with an in-flight prediction."""
+        import pytest
+        from tsconformal import (
+            CUSUMNormDetector,
+            PredictionSequenceError,
+            QuantileGridCDFAdapter,
+            SegmentedTransportCalibrator,
+            load_calibrator,
+            save_calibrator,
+        )
+
+        cdf = QuantileGridCDFAdapter([0.1, 0.5, 0.9], [-1.0, 0.0, 1.0])
+        cal = SegmentedTransportCalibrator(
+            grid_size=5,
+            rho=0.9,
+            n_eff_min=1.0,
+            step_schedule=lambda n: 0.1,
+            detector=CUSUMNormDetector(),
+            cooldown=5,
+            confirm=1,
+        )
+
+        cal.predict_cdf(cdf)
+        save_path = tmp_path / "pending_state.zip"
+        save_calibrator(cal, save_path)
+
+        cal_loaded = load_calibrator(save_path, step_schedule=lambda n: 0.1)
+        with pytest.raises(
+            PredictionSequenceError,
+            match="without a pending prediction",
+        ):
+            cal_loaded.update(0.0, cdf)
 
     def test_transport_ppf_propagates_unexpected_base_errors(self):
         """Unexpected adapter errors must not be masked by a scalar fallback."""


### PR DESCRIPTION
Closes #18

Target: 0.2.2rc1

## Summary

Strengthens the `SegmentedTransportCalibrator.predict_cdf()` / `update()` sequencing contract.

This PR adds explicit detection for invalid predict/update call sequences while preserving the existing heuristic warning behavior for ambiguous forecast-object mismatches.

## Changes

- Add public `PredictionSequenceError`
- Track transient pending prediction state inside `SegmentedTransportCalibrator`
- Raise `PredictionSequenceError` when:
  - `update()` is called without a pending prediction
  - `update()` is called after the pending prediction was already consumed
  - `update()` is called with a forecast id known to have been superseded
- Preserve the existing object-identity mismatch warning for ambiguous cases
- Keep pending prediction state transient and out of serialized calibrator state
- Clear transient sequencing state on load
- Export `PredictionSequenceError` through the public API
- Add focused sequencing and serialization regression tests

## Verification

- `PYTHONPATH=src:. pytest -q` -> `86 passed, 1 skipped`
- `PYTHONPATH=src:. mypy --ignore-missing-imports src` -> passed
- `git diff --check` -> clean

Note: local `ruff` was not available in this shell; CI will run the lint check.