### PR TITLE
Prepare 0.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.2.2 - 2026-04-20
+
+Stable release for stricter predict/update sequencing enforcement.
+
+### Changed
+
+- `SegmentedTransportCalibrator` now enforces the intended `predict_cdf()` /
+  `update()` sequencing contract more strictly.
+- `update()` now raises `PredictionSequenceError` for clear sequencing misuse,
+  including calls without a pending prediction, repeated updates after a
+  prediction has already been consumed, and updates using a forecast id known
+  to have been superseded.
+- Ambiguous forecast-object mismatches remain warning-only under the existing
+  heuristic object-identity check.
+- Pending prediction bookkeeping remains transient and is not serialized with
+  calibrator state.
+
 ## 0.2.2rc1 - 2026-04-20
 
 Release candidate for stricter predict/update sequencing enforcement.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Dara
 repository-code: https://github.com/daradehghan/segmented-conformal-transport
 license: MIT
-version: 0.2.2rc1
+version: 0.2.2
 date-released: 2026-04-20
 abstract: >
   Segmented Conformal Transport for one-step predictive CDF recalibration

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,4 @@ Companion paper (preprint DOI): https://doi.org/10.13140/RG.2.2.28984.30723
 
 ## Version
 
-This documentation tracks the published `tsconformal` v0.2.2rc1 release.
+This documentation tracks the published `tsconformal` v0.2.2 release.

--- a/docs/theory_alignment.md
+++ b/docs/theory_alignment.md
@@ -1,6 +1,6 @@
 # Theory Alignment
 
-This document maps `tsconformal` v0.2.2rc1 to the verified theory in *Conformal Calibration under Nonstationarity*.
+This document maps `tsconformal` v0.2.2 to the verified theory in *Conformal Calibration under Nonstationarity*.
 
 ## Theorem scope
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsconformal"
-version = "0.2.2rc1"
+version = "0.2.2"
 description = "Segmented Conformal Transport for predictive CDF recalibration under nonstationarity"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Target: 0.2.2

## Summary

Promotes the validated `0.2.2rc1` sequencing-enforcement release candidate to stable `0.2.2`.

## Changes

- Bump package version to `0.2.2`
- Update `CITATION.cff` release metadata
- Add the stable `0.2.2` changelog entry
- Update docs version references from `v0.2.2rc1` to `v0.2.2`

## Verification

- `PYTHONPATH=src:. python -m pytest -q`
- `python -m ruff check .`
- `PYTHONPATH=src:. python -m mypy --ignore-missing-imports src`
- `python -m build`
- `python -m twine check --strict dist/*`
- Wheel metadata confirms `Version: 0.2.2`
- sdist metadata confirms `Version: 0.2.2`