### PR TITLE
Add diagnostics extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,21 @@ The package now installs directly from PyPI.
 pip install tsconformal
 ```
 
+Optional extras are grouped by feature:
+
+- `pip install "tsconformal[diagnostics]"` for diagnostics helpers that use `statsmodels`
+- `pip install "tsconformal[plots]"` for plotting support; this extra still includes diagnostics dependencies for compatibility
+- `pip install "tsconformal[detectors]"` for optional detector-related tooling
+- `pip install "tsconformal[fm]"` for foundation-model forecast caching helpers
+
 The editable install below matches the development environment.
 
 ```bash
 python3.11 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install -e ".[plots,dev]"
-pip install ruptures statsmodels "chronos-forecasting>=2.0" torch
+pip install -e ".[plots,diagnostics,dev]"
+pip install -e ".[detectors,fm]"
 ```
 
 ## Minimal package example

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -2,6 +2,13 @@
 
 This page records the root-package public surface exposed by `import tsconformal`.
 
+## Optional extras
+
+- `tsconformal[diagnostics]` — installs `statsmodels` for diagnostics helpers such as `pit_uniformity_tests`
+- `tsconformal[plots]` — installs plotting support; this extra still includes diagnostics dependencies for compatibility
+- `tsconformal[detectors]` — installs optional detector-related tooling
+- `tsconformal[fm]` — installs foundation-model forecast caching dependencies
+
 ## Forecast interfaces
 
 ### `ForecastCDF` (Protocol)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,10 +8,16 @@ The published package installs directly from PyPI.
 pip install tsconformal
 ```
 
+Install the diagnostics extra if you want PIT diagnostics backed by `statsmodels`.
+
+```bash
+pip install "tsconformal[diagnostics]"
+```
+
 For local development, install from a checkout.
 
 ```bash
-pip install -e .
+pip install -e ".[diagnostics]"
 ```
 
 ## Basic Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Issues = "https://github.com/daradehghan/segmented-conformal-transport/issues"
 Documentation = "https://github.com/daradehghan/segmented-conformal-transport/tree/main/docs"
 
 [project.optional-dependencies]
+diagnostics = ["statsmodels>=0.14"]
 plots = ["matplotlib>=3.7", "statsmodels>=0.14"]
 detectors = ["ruptures>=1.1"]
 fm = [


### PR DESCRIPTION
Closes #20

Target: 0.2.3

## Summary

Adds a dedicated `diagnostics` optional dependency extra for diagnostics-related functionality while preserving existing extras compatibility.

## Changes

- Add `diagnostics` extra for `statsmodels`
- Preserve existing `plots` extra behavior
- Update install guidance in README and docs
- Avoid runtime code changes

## Verification

- `PYTHONPATH=src:. python -m pytest -q` → `86 passed, 1 skipped`
- `python -m ruff check .` → passed
- `PYTHONPATH=src:. python -m mypy --ignore-missing-imports src` → passed
- `python -m build` → passed
- `python -m twine check --strict dist/*` → passed
- wheel metadata confirms `Provides-Extra: diagnostics`
- wheel metadata includes `statsmodels`
- fresh venv smoke for `.[diagnostics]` → passed