### PR TITLE
Adopt PEP 440 release version policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
-      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      release_kind: ${{ steps.version.outputs.release_kind }}
     steps:
       - name: Check out repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -144,7 +144,7 @@ jobs:
     if: >
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v') &&
-      needs.version_guard.outputs.is_prerelease == 'true'
+      needs.version_guard.outputs.release_kind == 'rc'
     environment: testpypi
     permissions:
       contents: read
@@ -169,7 +169,7 @@ jobs:
     if: >
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/v') &&
-      needs.version_guard.outputs.is_prerelease == 'false'
+      needs.version_guard.outputs.release_kind == 'final'
     environment: pypi
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Adopt a PEP 440 development, release-candidate, and final-release
+  versioning policy.
+
 ## 0.2.2 - 2026-04-20
 
 Stable release for stricter predict/update sequencing enforcement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,56 @@ pip install -e ".[dev,plots,detectors]"
 PYTHONPATH=src:. pytest -q
 ```
 
+## Release versioning
+
+The project uses a narrow PEP 440 policy for committed package versions.
+
+Allowed committed forms are:
+
+- `X.Y.Z.devN` for normal development on `main`
+- `X.Y.ZrcN` for release candidates
+- `X.Y.Z` for final releases
+
+After each final release, `main` should move immediately to the next
+development version, for example from `0.2.2` to `0.2.3.dev0`.
+
+The release checker uses two validation modes. Source mode covers local checks,
+workflow-dispatch dry runs, branch pushes, and release-prep pull requests. Tag
+mode covers pushed release tags and adds tag/version matching plus the rule that
+development versions cannot be tagged.
+
+Development versions are source-tree versions only. They are not tagged and are
+not published to TestPyPI as part of the normal release workflow. Release
+candidates may be tagged as `vX.Y.ZrcN` and publish to TestPyPI plus a GitHub
+prerelease. Final releases are tagged as `vX.Y.Z` and publish to PyPI plus a
+GitHub release.
+
+Release metadata follows the committed version shape:
+
+- `X.Y.Z.devN` requires a `## Unreleased` changelog heading. `CITATION.cff`
+  stays pinned to the latest final citable release and is not required to match
+  the development version.
+- `X.Y.ZrcN` requires an exact `## X.Y.ZrcN` changelog heading. `CITATION.cff`
+  stays pinned to the latest final citable release and is not required to match
+  the release-candidate version.
+- `X.Y.Z` requires an exact `## X.Y.Z` changelog heading and a matching
+  `CITATION.cff` version.
+
+`CHANGELOG.md` is required in all validation modes. `CITATION.cff` is required
+when the committed package version is a final `X.Y.Z` release.
+
+Changelog headings used by the release checker must be bare h2 headings with no
+date or trailing text: `## Unreleased`, `## X.Y.ZrcN`, or `## X.Y.Z`.
+
+Release-prep pull requests may temporarily set `pyproject.toml` to `X.Y.ZrcN`
+or `X.Y.Z` before the tag exists. Those pull requests must include the matching
+changelog heading in the same change, and final-release prep must also align
+`CITATION.cff` with the final package version.
+
+Do not use `.postN` for ordinary development or maintenance work. Do not commit
+local versions such as `+gHASH`; local-version generation is outside the
+current release policy.
+
 ## Style
 
 Code changes should favor clarity, explicitness, and stable behavior over

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsconformal"
-version = "0.2.2"
+version = "0.2.3.dev0"
 description = "Segmented Conformal Transport for predictive CDF recalibration under nonstationarity"
 readme = "README.md"
 license = "MIT"

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -7,12 +7,15 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 import tomllib
 
 from packaging.version import InvalidVersion, Version
 import yaml
 
-STRICT_RELEASE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(rc\d+)?$")
+COMMITTED_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:\.dev\d+|rc\d+)?$")
+CHANGELOG_UNRELEASED_RE = re.compile(r"^##\s+Unreleased\s*$", re.MULTILINE)
+ReleaseKind = Literal["dev", "rc", "final"]
 
 
 class ReleaseVersionError(ValueError):
@@ -27,6 +30,7 @@ class ReleaseCheckResult:
     parsed_version: Version
     tag: str
     is_prerelease: bool
+    release_kind: ReleaseKind
     release_mode: bool
 
 
@@ -38,19 +42,48 @@ def set_output(name: str, value: str) -> None:
             handle.write(f"{name}={value}\n")
 
 
+def _supported_forms_message() -> str:
+    return "'X.Y.Z.devN', 'X.Y.ZrcN', or 'X.Y.Z'"
+
+
+def _release_kind(parsed_version: Version) -> ReleaseKind:
+    """Return the repository release kind for an already accepted version."""
+    if parsed_version.is_devrelease:
+        return "dev"
+    if parsed_version.pre is not None:
+        return "rc"
+    return "final"
+
+
 def validate_version_string(raw_version: str, label: str) -> Version:
-    """Require the repo's raw version policy and packaging semantics."""
-    if not STRICT_RELEASE_VERSION_RE.fullmatch(raw_version):
-        raise ReleaseVersionError(
-            f"{label} {raw_version!r} does not match the supported release forms "
-            "'X.Y.Z' or 'X.Y.ZrcN'."
-        )
+    """Require PEP 440 parsing plus the repo's narrower committed forms."""
     try:
-        return Version(raw_version)
+        parsed_version = Version(raw_version)
     except InvalidVersion as exc:
         raise ReleaseVersionError(
             f"{label} {raw_version!r} is not a valid Python package version."
         ) from exc
+
+    if len(parsed_version.release) != 3:
+        raise ReleaseVersionError(
+            f"{label} {raw_version!r} must use exactly three release segments "
+            "and one of the supported forms "
+            f"{_supported_forms_message()}."
+        )
+
+    if parsed_version.post is not None or parsed_version.local is not None:
+        raise ReleaseVersionError(
+            f"{label} {raw_version!r} uses a post-release or local version, "
+            "which is outside the repository release policy."
+        )
+
+    if not COMMITTED_VERSION_RE.fullmatch(raw_version) or str(parsed_version) != raw_version:
+        raise ReleaseVersionError(
+            f"{label} {raw_version!r} does not match the supported canonical "
+            f"forms {_supported_forms_message()}."
+        )
+
+    return parsed_version
 
 
 def read_project_version(pyproject_path: Path) -> tuple[str, Version]:
@@ -89,29 +122,69 @@ def require_matching_citation_version(
             f"CITATION.cff version {citation_raw!r} is not a valid Python package "
             "version."
         ) from exc
-    if citation_version != project_version:
+    if citation_raw != raw_project_version or citation_version != project_version:
         raise ReleaseVersionError(
             f"CITATION.cff version {citation_raw!r} does not match "
             f"pyproject.toml version {raw_project_version!r}."
         )
 
 
-def changelog_has_entry(changelog_path: Path, version: str) -> bool:
-    """Return True when CHANGELOG.md has a heading for the given version."""
+def changelog_has_exact_heading(changelog_path: Path, heading: str) -> bool:
+    """Return True when CHANGELOG.md has exactly the requested h2 heading."""
     content = changelog_path.read_text(encoding="utf-8")
-    pattern = re.compile(rf"^##\s+{re.escape(version)}\b", re.MULTILINE)
+    pattern = re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.MULTILINE)
     return pattern.search(content) is not None
 
 
-def require_changelog_entry(changelog_path: Path, version: str) -> None:
-    """Require CHANGELOG.md to contain a release heading for the version."""
+def require_changelog_heading(changelog_path: Path, heading: str) -> None:
+    """Require CHANGELOG.md to contain an exact h2 heading."""
     if not changelog_path.exists():
         raise ReleaseVersionError(
-            "CHANGELOG.md must exist before automated public releases."
+            "CHANGELOG.md must exist before release metadata validation."
         )
-    if not changelog_has_entry(changelog_path, version):
+    if not changelog_has_exact_heading(changelog_path, heading):
         raise ReleaseVersionError(
-            f"CHANGELOG.md does not contain an entry for version {version!r}."
+            f"CHANGELOG.md does not contain an exact heading {heading!r}."
+        )
+
+
+def require_unreleased_changelog_heading(changelog_path: Path) -> None:
+    """Require CHANGELOG.md to contain the canonical development heading."""
+    if not changelog_path.exists():
+        raise ReleaseVersionError(
+            "CHANGELOG.md must exist before release metadata validation."
+        )
+    content = changelog_path.read_text(encoding="utf-8")
+    if CHANGELOG_UNRELEASED_RE.search(content) is None:
+        raise ReleaseVersionError(
+            "CHANGELOG.md does not contain the required '## Unreleased' heading "
+            "for development versions."
+        )
+
+
+def _validate_metadata_for_version_shape(
+    *,
+    release_kind: ReleaseKind,
+    raw_project_version: str,
+    parsed_project_version: Version,
+    citation_path: Path,
+    changelog_path: Path,
+) -> None:
+    """Apply metadata checks implied by the committed version shape."""
+    if release_kind == "dev":
+        require_unreleased_changelog_heading(changelog_path)
+        return
+
+    require_changelog_heading(changelog_path, raw_project_version)
+    if release_kind == "final":
+        if not citation_path.exists():
+            raise ReleaseVersionError(
+                "CITATION.cff must exist for final release validation."
+            )
+        require_matching_citation_version(
+            citation_path,
+            raw_project_version,
+            parsed_project_version,
         )
 
 
@@ -127,49 +200,39 @@ def check_release_version(
     changelog_path = repo_root / "CHANGELOG.md"
 
     raw_project_version, parsed_project_version = read_project_version(pyproject_path)
+    release_kind = _release_kind(parsed_project_version)
     release_mode = event_name == "push" and bool(ref_name) and ref_name.startswith("v")
 
     tag = ""
     if release_mode:
         tag = str(ref_name)
-        if not tag.startswith("v"):
-            raise ReleaseVersionError(
-                f"Release tag {tag!r} must start with the 'v' prefix."
-            )
         raw_tag_version = tag[1:]
         parsed_tag_version = validate_version_string(raw_tag_version, "Tag version")
+        if release_kind == "dev":
+            raise ReleaseVersionError(
+                "Development versions cannot be tagged or published; bump to "
+                "a release candidate or final version before pushing a release tag."
+            )
         if parsed_tag_version != parsed_project_version:
             raise ReleaseVersionError(
                 f"Tag version {raw_tag_version!r} does not match "
                 f"pyproject.toml version {raw_project_version!r}."
             )
 
-    if citation_path.exists():
-        require_matching_citation_version(
-            citation_path,
-            raw_project_version,
-            parsed_project_version,
-        )
-    elif release_mode:
-        raise ReleaseVersionError(
-            "CITATION.cff must exist for tag-based release validation."
-        )
-
-    if release_mode:
-        require_changelog_entry(changelog_path, raw_project_version)
-    elif changelog_path.exists() and not changelog_has_entry(
-        changelog_path, raw_project_version
-    ):
-        print(
-            f"CHANGELOG.md does not yet contain an entry for version "
-            f"{raw_project_version!r}.",
-        )
+    _validate_metadata_for_version_shape(
+        release_kind=release_kind,
+        raw_project_version=raw_project_version,
+        parsed_project_version=parsed_project_version,
+        citation_path=citation_path,
+        changelog_path=changelog_path,
+    )
 
     return ReleaseCheckResult(
         version=raw_project_version,
         parsed_version=parsed_project_version,
         tag=tag,
         is_prerelease=parsed_project_version.is_prerelease,
+        release_kind=release_kind,
         release_mode=release_mode,
     )
 
@@ -213,15 +276,20 @@ def main(argv: list[str] | None = None) -> int:
 
     set_output("version", result.version)
     set_output("tag", result.tag)
+    # Kept for external consumers; release workflow routing must use release_kind.
     set_output("is_prerelease", str(result.is_prerelease).lower())
+    set_output("release_kind", result.release_kind)
 
     if result.release_mode:
         print(
             f"Validated release tag {result.tag!r} against package version "
-            f"{result.version!r}."
+            f"{result.version!r} ({result.release_kind})."
         )
     else:
-        print(f"Validated package version {result.version!r} for dry-run mode.")
+        print(
+            f"Validated package version {result.version!r} "
+            f"({result.release_kind}) for source mode."
+        )
 
     return 0
 

--- a/tests/regression/test_release_version.py
+++ b/tests/regression/test_release_version.py
@@ -15,7 +15,7 @@ def _write_release_files(
     *,
     version: str = "0.2.0",
     citation_version: str | None = None,
-    changelog_versions: tuple[str, ...] = ("0.2.0",),
+    changelog_headings: tuple[str, ...] = ("0.2.0",),
 ) -> None:
     repo_root.joinpath("pyproject.toml").write_text(
         textwrap.dedent(
@@ -42,12 +42,12 @@ def _write_release_files(
             encoding="utf-8",
         )
 
-    if changelog_versions:
+    if changelog_headings:
         changelog = ["# Changelog", ""]
-        for release_version in changelog_versions:
+        for heading in changelog_headings:
             changelog.extend(
                 [
-                    f"## {release_version} - 2026-04-18",
+                    f"## {heading}",
                     "",
                     "### Changed",
                     "",
@@ -63,15 +63,234 @@ def _write_release_files(
 
 @pytest.mark.parametrize(
     "raw_version",
-    ["0.2", "0.2.0.dev1", "0.2.0.post1", "0.2.0+local", "0.2.0-rc.1"],
+    ["0.2.0.dev1", "0.2.0rc1", "0.2.0"],
+)
+def test_validate_version_string_accepts_policy_forms(raw_version):
+    parsed = validate_version_string(raw_version, "Project version")
+
+    assert str(parsed) == raw_version
+
+
+@pytest.mark.parametrize(
+    "raw_version",
+    [
+        "0.2",
+        "0.2.0.post1",
+        "0.2.0+local",
+        "0.2.0-rc.1",
+        "0.2.0c1",
+        "0.2.0.rc1",
+        "0.2.0dev1",
+        "0.2.0RC1",
+    ],
 )
 def test_validate_version_string_rejects_disallowed_forms(raw_version):
     with pytest.raises(ReleaseVersionError):
         validate_version_string(raw_version, "Project version")
 
 
-def test_tag_push_requires_matching_version_metadata(tmp_path):
-    _write_release_files(tmp_path, version="0.2.0", citation_version="0.2.0")
+@pytest.mark.parametrize(
+    ("version", "heading", "expected_kind"),
+    [
+        ("0.2.3.dev0", "Unreleased", "dev"),
+        ("0.2.3.dev1", "Unreleased", "dev"),
+        ("0.2.3rc1", "0.2.3rc1", "rc"),
+        ("0.2.3", "0.2.3", "final"),
+    ],
+)
+def test_source_mode_accepts_dev_rc_and_final_versions(
+    tmp_path,
+    version,
+    heading,
+    expected_kind,
+):
+    citation_version = "0.2.3" if expected_kind == "final" else "0.2.2"
+    _write_release_files(
+        tmp_path,
+        version=version,
+        citation_version=citation_version,
+        changelog_headings=(heading,),
+    )
+
+    result = check_release_version(
+        tmp_path,
+        event_name="workflow_dispatch",
+    )
+
+    assert result.version == version
+    assert result.tag == ""
+    assert result.release_kind == expected_kind
+
+
+def test_branch_push_with_dev_version_uses_source_mode(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3.dev0",
+        citation_version="0.2.2",
+        changelog_headings=("Unreleased",),
+    )
+
+    result = check_release_version(
+        tmp_path,
+        event_name="push",
+        ref_name="main",
+    )
+
+    assert result.version == "0.2.3.dev0"
+    assert result.release_kind == "dev"
+    assert result.release_mode is False
+    assert result.is_prerelease is True
+
+
+def test_source_mode_dev_requires_unreleased_changelog_heading(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3.dev0",
+        citation_version="0.2.2",
+        changelog_headings=("0.2.3",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="Unreleased"):
+        check_release_version(
+            tmp_path,
+            event_name="workflow_dispatch",
+        )
+
+
+def test_source_mode_rc_accepts_exact_rc_changelog_heading(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3rc1",
+        citation_version="0.2.2",
+        changelog_headings=("0.2.3rc1",),
+    )
+
+    result = check_release_version(
+        tmp_path,
+        event_name="workflow_dispatch",
+    )
+
+    assert result.release_kind == "rc"
+
+
+def test_source_mode_rc_fails_without_exact_rc_changelog_heading(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3rc1",
+        citation_version="0.2.2",
+        changelog_headings=("Unreleased",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="0.2.3rc1"):
+        check_release_version(
+            tmp_path,
+            event_name="workflow_dispatch",
+        )
+
+
+@pytest.mark.parametrize("citation_version", [None, "0.2.2", "999.0.0"])
+def test_source_mode_rc_does_not_require_matching_citation_version(
+    tmp_path,
+    citation_version,
+):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3rc1",
+        citation_version=citation_version,
+        changelog_headings=("0.2.3rc1",),
+    )
+
+    result = check_release_version(
+        tmp_path,
+        event_name="workflow_dispatch",
+    )
+
+    assert result.version == "0.2.3rc1"
+    assert result.release_kind == "rc"
+
+
+def test_source_mode_final_requires_changelog_and_matching_citation(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3",
+        citation_version="0.2.3",
+        changelog_headings=("0.2.3",),
+    )
+
+    result = check_release_version(
+        tmp_path,
+        event_name="workflow_dispatch",
+    )
+
+    assert result.release_kind == "final"
+
+
+def test_source_mode_final_fails_without_matching_citation_version(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3",
+        citation_version="0.2.2",
+        changelog_headings=("0.2.3",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="CITATION.cff version"):
+        check_release_version(
+            tmp_path,
+            event_name="workflow_dispatch",
+        )
+
+
+def test_source_mode_final_requires_citation_file(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3",
+        changelog_headings=("0.2.3",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="CITATION.cff must exist"):
+        check_release_version(
+            tmp_path,
+            event_name="workflow_dispatch",
+        )
+
+
+def test_source_mode_final_fails_without_exact_changelog_heading(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3",
+        citation_version="0.2.3",
+        changelog_headings=("Unreleased",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="0.2.3"):
+        check_release_version(
+            tmp_path,
+            event_name="workflow_dispatch",
+        )
+
+
+def test_source_mode_requires_changelog_file(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3.dev0",
+        citation_version="0.2.2",
+        changelog_headings=(),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="CHANGELOG.md must exist"):
+        check_release_version(
+            tmp_path,
+            event_name="workflow_dispatch",
+        )
+
+
+def test_tag_push_requires_matching_final_version_metadata(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0",
+        citation_version="0.2.0",
+        changelog_headings=("0.2.0",),
+    )
 
     result = check_release_version(
         tmp_path,
@@ -81,15 +300,16 @@ def test_tag_push_requires_matching_version_metadata(tmp_path):
 
     assert result.version == "0.2.0"
     assert result.tag == "v0.2.0"
+    assert result.release_kind == "final"
     assert result.is_prerelease is False
 
 
-def test_tag_push_marks_release_candidates_as_prereleases(tmp_path):
+def test_tag_push_accepts_release_candidate_without_citation_match(tmp_path):
     _write_release_files(
         tmp_path,
         version="0.2.0rc1",
-        citation_version="0.2.0rc1",
-        changelog_versions=("0.2.0rc1",),
+        citation_version="0.1.0",
+        changelog_headings=("0.2.0rc1",),
     )
 
     result = check_release_version(
@@ -100,11 +320,107 @@ def test_tag_push_marks_release_candidates_as_prereleases(tmp_path):
 
     assert result.version == "0.2.0rc1"
     assert result.tag == "v0.2.0rc1"
+    assert result.release_kind == "rc"
     assert result.is_prerelease is True
 
 
-def test_tag_push_rejects_mismatched_citation_version(tmp_path):
-    _write_release_files(tmp_path, version="0.2.0", citation_version="0.2.1")
+def test_tag_push_rc_requires_exact_changelog_heading(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0rc1",
+        citation_version="0.1.0",
+        changelog_headings=("Unreleased",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="0.2.0rc1"):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name="v0.2.0rc1",
+        )
+
+
+def test_tag_push_rejects_development_versions_with_clear_error(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3.dev0",
+        citation_version="0.2.2",
+        changelog_headings=("Unreleased",),
+    )
+
+    with pytest.raises(
+        ReleaseVersionError,
+        match="Development versions cannot be tagged",
+    ):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name="v0.2.3.dev0",
+        )
+
+
+def test_tag_push_rejects_development_project_version_with_final_tag(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.3.dev0",
+        citation_version="0.2.2",
+        changelog_headings=("Unreleased",),
+    )
+
+    with pytest.raises(
+        ReleaseVersionError,
+        match="Development versions cannot be tagged.*bump",
+    ):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name="v0.2.3",
+        )
+
+
+@pytest.mark.parametrize(
+    "ref_name",
+    ["v0.2.0c1", "v0.2.0RC1", "v0.2.0.rc1"],
+)
+def test_tag_push_rejects_non_policy_tag_versions(tmp_path, ref_name):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0",
+        citation_version="0.2.0",
+        changelog_headings=("0.2.0",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="Tag version"):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name=ref_name,
+        )
+
+
+def test_tag_push_rejects_mismatched_project_and_tag_versions(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0",
+        citation_version="0.2.0",
+        changelog_headings=("0.2.0",),
+    )
+
+    with pytest.raises(ReleaseVersionError, match="Tag version"):
+        check_release_version(
+            tmp_path,
+            event_name="push",
+            ref_name="v0.2.1",
+        )
+
+
+def test_tag_push_rejects_mismatched_final_citation_version(tmp_path):
+    _write_release_files(
+        tmp_path,
+        version="0.2.0",
+        citation_version="0.2.1",
+        changelog_headings=("0.2.0",),
+    )
 
     with pytest.raises(ReleaseVersionError, match="CITATION.cff version"):
         check_release_version(
@@ -114,15 +430,15 @@ def test_tag_push_rejects_mismatched_citation_version(tmp_path):
         )
 
 
-def test_tag_push_requires_matching_changelog_entry(tmp_path):
+def test_tag_push_requires_exact_final_changelog_heading(tmp_path):
     _write_release_files(
         tmp_path,
         version="0.2.0",
         citation_version="0.2.0",
-        changelog_versions=("0.1.0",),
+        changelog_headings=("0.2.0 - 2026-04-18",),
     )
 
-    with pytest.raises(ReleaseVersionError, match="CHANGELOG.md does not contain"):
+    with pytest.raises(ReleaseVersionError, match="0.2.0"):
         check_release_version(
             tmp_path,
             event_name="push",
@@ -130,12 +446,12 @@ def test_tag_push_requires_matching_changelog_entry(tmp_path):
         )
 
 
-def test_manual_dry_run_does_not_require_a_tag(tmp_path, monkeypatch):
+def test_manual_dry_run_emits_release_kind_output(tmp_path, monkeypatch):
     _write_release_files(
         tmp_path,
-        version="0.2.0",
-        citation_version="0.2.0",
-        changelog_versions=(),
+        version="0.2.3.dev0",
+        citation_version="0.2.2",
+        changelog_headings=("Unreleased",),
     )
     github_output = tmp_path / "github-output.txt"
     monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
@@ -151,7 +467,8 @@ def test_manual_dry_run_does_not_require_a_tag(tmp_path, monkeypatch):
 
     assert exit_code == 0
     assert github_output.read_text(encoding="utf-8").splitlines() == [
-        "version=0.2.0",
+        "version=0.2.3.dev0",
         "tag=",
-        "is_prerelease=false",
+        "is_prerelease=true",
+        "release_kind=dev",
     ]


### PR DESCRIPTION
## Summary

- Adopt a strict PEP 440 release-version policy for development, release-candidate, and final versions.
- Add source/tag validation modes, release-kind outputs, metadata gates, and workflow routing based on `release_kind`.
- Bootstrap the repository to `0.2.3.dev0` while keeping `CITATION.cff` pinned to the last final release.
- Document the release protocol in `CONTRIBUTING.md` and expand regression coverage for validator behavior.

## Validation

- `PYTHONPATH=src:. python -m pytest tests/regression/test_release_version.py -q`
- `PYTHONPATH=src:. python -m pytest -q`
- `PYTHONPATH=src:. python -m ruff check .`
- `PYTHONPATH=src:. python -m mypy --ignore-missing-imports src`
- `python scripts/check_release_version.py`

Closes #33